### PR TITLE
Update Jacoco and POI library versions

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -60,7 +60,7 @@ extra["junitVersion"] = "5.12.0"
 extra["springCloudBomVersion"] = "2024.0.1"
 extra["spotbugsAnnotationVersion"] = "4.9.2"
 extra["libphonenumberVersion"] = "9.0.0"
-extra["poiVersion"] = "5.2.5"
+extra["poiVersion"] = "5.4.1"
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
@@ -132,6 +132,7 @@ dependencyManagement {
 jacoco {
     toolVersion = "0.8.12"
     // reportsDirectory = layout.buildDirectory.dir("customJacocoReportDir")
+
 }
 
 tasks.test {

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -135,11 +135,15 @@ jacoco {
 
 }
 
+tasks.jacocoTestReport {
+    dependsOn(tasks.test) // tests are required to run before generating the report
+}
 tasks.test {
     useJUnitPlatform {
         excludeTags("medium", "large")
         timeout.set(Duration.ofSeconds(60))
     }
+    finalizedBy(tasks.jacocoTestReport) // report is always generated after tests run
 }
 
 val mediumTest = tasks.register("mediumTest", Test::class.java) {

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -130,20 +130,24 @@ dependencyManagement {
     }
 }
 jacoco {
-    toolVersion = "0.8.12"
+    toolVersion = "0.8.13"
     // reportsDirectory = layout.buildDirectory.dir("customJacocoReportDir")
-
 }
 
 tasks.jacocoTestReport {
     dependsOn(tasks.test) // tests are required to run before generating the report
+    reports {
+        xml.required = false
+        csv.required = false
+        html.outputLocation = layout.buildDirectory.dir("reports/jacoco")
+    }
 }
 tasks.test {
     useJUnitPlatform {
         excludeTags("medium", "large")
         timeout.set(Duration.ofSeconds(60))
     }
-    finalizedBy(tasks.jacocoTestReport) // report is always generated after tests run
+    finalizedBy(tasks.jacocoTestReport) // a report is always generated after tests run
 }
 
 val mediumTest = tasks.register("mediumTest", Test::class.java) {
@@ -163,13 +167,6 @@ val largeTest = tasks.register("largeTest", Test::class.java) {
     shouldRunAfter("mediumTest")
 }
 
-tasks.jacocoTestReport {
-    reports {
-        xml.required = false
-        csv.required = false
-        html.outputLocation = layout.buildDirectory.dir("jacocoHtml")
-    }
-}
 apply(plugin = "com.github.ben-manes.versions")
 
 


### PR DESCRIPTION
### Summary

- Updated Jacoco tool to version 0.8.13 and modified its configuration:
  - Changed HTML report output directory to `reports/jacoco`.
  - Removed redundant task settings for simplification.
- Added task configuration to auto-generate Jacoco test reports after test execution.
- Updated Apache POI library to the latest version 5.4.1, improving security and stability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Apache POI and Jacoco plugin versions.
  - Improved test coverage reporting: coverage reports are now generated automatically after tests, with reports available in HTML format only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

fixs: #22 