### PR TITLE
refactor: simplify `value()` method implementation

### DIFF
--- a/backend/src/main/java/undecided/erp/common/entity/IntegerValue.java
+++ b/backend/src/main/java/undecided/erp/common/entity/IntegerValue.java
@@ -9,8 +9,8 @@ import undecided.erp.common.precondition.IntegerPrecondition;
 /**
  * IntegerValueクラスは、型Integerの単一の値をカプセル化する値オブジェクトを表します。
  * このクラスは、Integer型でパラメータ化されたSingleValueクラスの機能を拡張し、 整数値を処理するための特定の実装を提供します。
- * <p>
- * このクラスは、型付けが強い整数値の値オブジェクトとしての表現が必要な状況で使用されることを意図しています。
+ *
+ * <p>このクラスは、型付けが強い整数値の値オブジェクトとしての表現が必要な状況で使用されることを意図しています。
  *
  * @param <VO> 値オブジェクトのタイプを表します。
  */
@@ -19,11 +19,11 @@ public interface IntegerValue<VO extends IntegerValue<VO>> extends SingleValue<I
   /**
    * IntegerValuesクラスは、数値に対する検証を行うためのユーティリティクラスです。 このクラスでは、数値が特定の条件を満たしているかどうかを確認し、
    * 条件に一致しない場合にカスタム例外をスローするメソッドを提供します。
-   * <p>
-   * 提供されている各メソッドは以下の用途に使用できます: - 数値が正であるかを検証 - 数値が正またはゼロであるかを検証 - 数値が負であるかを検証 - 数値が負またはゼロであるかを検証 -
-   * 数値が特定の範囲内にあるかを検証
-   * <p>
-   * このクラスは、数値検証の再利用可能で効率的な手段を提供し、 不適切な数値入力を防ぐ補助となります。
+   *
+   * <p>提供されている各メソッドは以下の用途に使用できます: - 数値が正であるかを検証 - 数値が正またはゼロであるかを検証 - 数値が負であるかを検証 - 数値が負またはゼロであるかを検証
+   * - 数値が特定の範囲内にあるかを検証
+   *
+   * <p>このクラスは、数値検証の再利用可能で効率的な手段を提供し、 不適切な数値入力を防ぐ補助となります。
    */
   class IntegerValues {
 
@@ -35,8 +35,8 @@ public interface IntegerValue<VO extends IntegerValue<VO>> extends SingleValue<I
      * @return 参照がnullでなく、正の場合は正の参照。
      * @throws RuntimeException 参照がnullまたは正でない場合。
      */
-    public static <VO extends IntegerValue<VO>> VO checkPositive(VO ref,
-        @NonNull Supplier<? extends RuntimeException> exceptionSupplier) {
+    public static <VO extends IntegerValue<VO>> VO checkPositive(
+        VO ref, @NonNull Supplier<? extends RuntimeException> exceptionSupplier) {
       return checkGreaterThan(ref, exceptionSupplier, 0);
     }
 
@@ -48,39 +48,38 @@ public interface IntegerValue<VO extends IntegerValue<VO>> extends SingleValue<I
      * @return 与えられた値が正またはゼロである場合、同じIntegerの値が返ります。それ以外の場合、exceptionSupplierに基づいて例外が投げられます。
      * @throws RuntimeException 与えられた値が負の場合、exceptionSupplierに基づいて投げられます。
      */
-    public static <VO extends IntegerValue<VO>> VO checkNonNegative(VO ref,
-        @NonNull Supplier<? extends RuntimeException> exceptionSupplier) {
+    public static <VO extends IntegerValue<VO>> VO checkNonNegative(
+        VO ref, @NonNull Supplier<? extends RuntimeException> exceptionSupplier) {
       return checkAtLest(ref, exceptionSupplier, 0);
-
     }
 
     /**
      * 与えられた参照が負であるかを確認し、そうでなければRuntimeExceptionをスローします。
-     * <p>
-     * 参照がnullの場合、変更せずに返されます。
+     *
+     * <p>参照がnullの場合、変更せずに返されます。
      *
      * @param ref 確認する参照
      * @param exceptionSupplier 参照が負でない場合にRuntimeExceptionを提供するSupplier
      * @return 参照が負の場合は参照を、nullであればnullを返します
      * @throws RuntimeException 参照が負でない場合
      */
-    public static <VO extends IntegerValue<VO>> VO checkNegative(VO ref,
-        @NonNull Supplier<? extends RuntimeException> exceptionSupplier) {
+    public static <VO extends IntegerValue<VO>> VO checkNegative(
+        VO ref, @NonNull Supplier<? extends RuntimeException> exceptionSupplier) {
       return checkLessThan(ref, exceptionSupplier, 0);
     }
 
     /**
      * 与えられた数値が負の数またはゼロであるかを確認します。
-     * <p>
-     * 参照数がnullの場合、nullを返します。参照数がゼロより大きい場合、指定された例外を投げます。
+     *
+     * <p>参照数がnullの場合、nullを返します。参照数がゼロより大きい場合、指定された例外を投げます。
      *
      * @param ref 検証する数値。
      * @param exceptionSupplier 数値がゼロより大きい場合に投げる例外を提供するSupplier。
      * @return 数値がnullまたはゼロ以下である場合、同じ数値を返します。それ以外の場合は、例外が投げられます。
      * @throws RuntimeException 数値がゼロより大きい場合。
      */
-    public static <VO extends IntegerValue<VO>> VO checkNegativeOrZero(final VO ref,
-        final @NonNull Supplier<? extends RuntimeException> exceptionSupplier) {
+    public static <VO extends IntegerValue<VO>> VO checkNegativeOrZero(
+        final VO ref, final @NonNull Supplier<? extends RuntimeException> exceptionSupplier) {
       return checkAtMost(ref, exceptionSupplier, 0);
     }
 
@@ -94,15 +93,16 @@ public interface IntegerValue<VO extends IntegerValue<VO>> extends SingleValue<I
      * @return 検証済みのInteger値。
      * @throws RuntimeException Integer値が指定された閉範囲内にない場合。
      */
-    public static <VO extends IntegerValue<VO>> VO checkRangeClosed(VO ref,
+    public static <VO extends IntegerValue<VO>> VO checkRangeClosed(
+        VO ref,
         @NonNull Supplier<? extends RuntimeException> exceptionSupplier,
-        @NonNull Integer min, @NonNull Integer max) {
+        @NonNull Integer min,
+        @NonNull Integer max) {
       if (isNull(ref)) {
         return null;
       }
-      IntegerPrecondition.checkRangeClosed(ref.getValue(), exceptionSupplier, min, max);
+      IntegerPrecondition.checkRangeClosed(ref.value(), exceptionSupplier, min, max);
       return ref;
-
     }
 
     /**
@@ -110,21 +110,22 @@ public interface IntegerValue<VO extends IntegerValue<VO>> extends SingleValue<I
      *
      * @param ref 検証対象となるInteger値。
      * @param exceptionSupplier Integer値が範囲外である場合にスローするRuntimeExceptionを返すsupplier関数。
-     * このsupplier関数はnullであってはなりません。
+     *     このsupplier関数はnullであってはなりません。
      * @param min 範囲の最小値。
      * @param max 範囲の最大値。
      * @return 検証されたInteger値。
      * @throws RuntimeException Integer値が指定した開放範囲内にない場合。
      */
-    public static <VO extends IntegerValue<VO>> VO checkRangeOpen(VO ref,
+    public static <VO extends IntegerValue<VO>> VO checkRangeOpen(
+        VO ref,
         @NonNull Supplier<? extends RuntimeException> exceptionSupplier,
-        @NonNull Integer min, @NonNull Integer max) {
+        @NonNull Integer min,
+        @NonNull Integer max) {
       if (isNull(ref)) {
         return null;
       }
-      IntegerPrecondition.checkRangeOpen(ref.getValue(), exceptionSupplier, min, max);
+      IntegerPrecondition.checkRangeOpen(ref.value(), exceptionSupplier, min, max);
       return ref;
-
     }
 
     /**
@@ -132,21 +133,22 @@ public interface IntegerValue<VO extends IntegerValue<VO>> extends SingleValue<I
      *
      * @param ref 検証するInteger型の値。
      * @param exceptionSupplier Integer型の値が範囲外の場合にRuntimeExceptionを返すサプライヤー関数。
-     * このサプライヤー関数は非nullでなければなりません。
+     *     このサプライヤー関数は非nullでなければなりません。
      * @param min 閉区間-開区間の範囲の最小値。
      * @param max 閉区間-開区間の範囲の最大値。
      * @return 検証済みのInteger型の値。
      * @throws RuntimeException Integer型の値が指定された閉区間-開区間の範囲内にない場合。
      */
-    public static <VO extends IntegerValue<VO>> VO checkRangeClosedOpen(VO ref,
-        @NonNull Supplier<? extends RuntimeException> exceptionSupplier, @NonNull Integer min,
+    public static <VO extends IntegerValue<VO>> VO checkRangeClosedOpen(
+        VO ref,
+        @NonNull Supplier<? extends RuntimeException> exceptionSupplier,
+        @NonNull Integer min,
         @NonNull Integer max) {
       if (isNull(ref)) {
         return null;
       }
-      IntegerPrecondition.checkRangeClosedOpen(ref.getValue(), exceptionSupplier, min, max);
+      IntegerPrecondition.checkRangeClosedOpen(ref.value(), exceptionSupplier, min, max);
       return ref;
-
     }
 
     /**
@@ -154,27 +156,28 @@ public interface IntegerValue<VO extends IntegerValue<VO>> extends SingleValue<I
      *
      * @param ref 検証するInteger値。
      * @param exceptionSupplier Integer値が範囲外の場合に投げられるRuntimeExceptionを返すサプライヤー関数。
-     * このサプライヤー関数はnullであってはなりません。
+     *     このサプライヤー関数はnullであってはなりません。
      * @param min 開放-閉鎖範囲の最小値。
      * @param max 開放-閉鎖範囲の最大値。
      * @return 検証したInteger値。
      * @throws RuntimeException Integer値が指定した開放-閉鎖範囲内にない場合。
      */
-    public static <VO extends IntegerValue<VO>> VO checkRangeOpenClosed(VO ref,
-        @NonNull Supplier<? extends RuntimeException> exceptionSupplier, @NonNull Integer min,
+    public static <VO extends IntegerValue<VO>> VO checkRangeOpenClosed(
+        VO ref,
+        @NonNull Supplier<? extends RuntimeException> exceptionSupplier,
+        @NonNull Integer min,
         @NonNull Integer max) {
       if (isNull(ref)) {
         return null;
       }
-      IntegerPrecondition.checkRangeOpenClosed(ref.getValue(), exceptionSupplier, min, max);
+      IntegerPrecondition.checkRangeOpenClosed(ref.value(), exceptionSupplier, min, max);
       return ref;
-
     }
 
     /**
      * 指定された整数値が範囲の最小値以上であることを検証します。
-     * <p>
-     * 値が範囲内にない場合、exceptionSupplierによって提供されるRuntimeExceptionをスローします。
+     *
+     * <p>値が範囲内にない場合、exceptionSupplierによって提供されるRuntimeExceptionをスローします。
      *
      * @param ref 検証する整数値です。
      * @param exceptionSupplier 値が範囲外の場合にRuntimeExceptionを返す関数です。 この関数は null であってはなりません。
@@ -182,14 +185,15 @@ public interface IntegerValue<VO extends IntegerValue<VO>> extends SingleValue<I
      * @return 検証された整数値。
      * @throws RuntimeException 整数値が指定された最小値以上でない場合にスローされます。
      */
-    public static <VO extends IntegerValue<VO>> VO checkAtLest(VO ref,
-        @NonNull Supplier<? extends RuntimeException> exceptionSupplier, @NonNull Integer min) {
+    public static <VO extends IntegerValue<VO>> VO checkAtLest(
+        VO ref,
+        @NonNull Supplier<? extends RuntimeException> exceptionSupplier,
+        @NonNull Integer min) {
       if (isNull(ref)) {
         return null;
       }
-      IntegerPrecondition.checkAtLest(ref.getValue(), exceptionSupplier, min);
+      IntegerPrecondition.checkAtLest(ref.value(), exceptionSupplier, min);
       return ref;
-
     }
 
     /**
@@ -201,15 +205,16 @@ public interface IntegerValue<VO extends IntegerValue<VO>> extends SingleValue<I
      * @return 検証されたInteger値を返します。
      * @throws RuntimeException Integer値が指定範囲内に存在しない場合にスローされます。
      */
-    public static <VO extends IntegerValue<VO>> VO checkAtMost(VO ref,
-        @NonNull Supplier<? extends RuntimeException> exceptionSupplier, @NonNull Integer max) {
+    public static <VO extends IntegerValue<VO>> VO checkAtMost(
+        VO ref,
+        @NonNull Supplier<? extends RuntimeException> exceptionSupplier,
+        @NonNull Integer max) {
       if (isNull(ref)) {
         return null;
       }
 
-      IntegerPrecondition.checkAtMost(ref.getValue(), exceptionSupplier, max);
+      IntegerPrecondition.checkAtMost(ref.value(), exceptionSupplier, max);
       return ref;
-
     }
 
     /**
@@ -221,14 +226,15 @@ public interface IntegerValue<VO extends IntegerValue<VO>> extends SingleValue<I
      * @return 検証済みのIntegerの値。
      * @throws RuntimeException Integerの値が指定された最大値未満でない場合。
      */
-    public static <VO extends IntegerValue<VO>> VO checkLessThan(VO ref,
-        @NonNull Supplier<? extends RuntimeException> exceptionSupplier, @NonNull Integer max) {
+    public static <VO extends IntegerValue<VO>> VO checkLessThan(
+        VO ref,
+        @NonNull Supplier<? extends RuntimeException> exceptionSupplier,
+        @NonNull Integer max) {
       if (isNull(ref)) {
         return null;
       }
-      IntegerPrecondition.checkLessThan(ref.getValue(), exceptionSupplier, max);
+      IntegerPrecondition.checkLessThan(ref.value(), exceptionSupplier, max);
       return ref;
-
     }
 
     /**
@@ -240,16 +246,16 @@ public interface IntegerValue<VO extends IntegerValue<VO>> extends SingleValue<I
      * @return 検証されたInteger値。
      * @throws RuntimeException Integer値が最小値よりも大きくない場合。
      */
-    public static <VO extends IntegerValue<VO>> VO checkGreaterThan(VO ref,
-        @NonNull Supplier<? extends RuntimeException> exceptionSupplier, @NonNull Integer min) {
+    public static <VO extends IntegerValue<VO>> VO checkGreaterThan(
+        VO ref,
+        @NonNull Supplier<? extends RuntimeException> exceptionSupplier,
+        @NonNull Integer min) {
       if (ref == null) {
         return ref;
       }
 
-      IntegerPrecondition.checkGreaterThan(ref.getValue(), exceptionSupplier, min);
+      IntegerPrecondition.checkGreaterThan(ref.value(), exceptionSupplier, min);
       return ref;
-
     }
-
   }
 }

--- a/backend/src/main/java/undecided/erp/common/entity/LongValue.java
+++ b/backend/src/main/java/undecided/erp/common/entity/LongValue.java
@@ -92,7 +92,7 @@ public interface LongValue<VO extends LongValue<VO>> extends SingleValue<Long> {
       if (isNull(ref)) {
         return null;
       }
-      LongPrecondition.checkRangeClosed(ref.getValue(), exceptionSupplier, min, max);
+      LongPrecondition.checkRangeClosed(ref.value(), exceptionSupplier, min, max);
       return ref;
     }
 
@@ -115,7 +115,7 @@ public interface LongValue<VO extends LongValue<VO>> extends SingleValue<Long> {
       if (isNull(ref)) {
         return null;
       }
-      LongPrecondition.checkRangeOpen(ref.getValue(), exceptionSupplier, min, max);
+      LongPrecondition.checkRangeOpen(ref.value(), exceptionSupplier, min, max);
       return ref;
     }
 
@@ -138,7 +138,7 @@ public interface LongValue<VO extends LongValue<VO>> extends SingleValue<Long> {
       if (isNull(ref)) {
         return null;
       }
-      LongPrecondition.checkRangeClosedOpen(ref.getValue(), exceptionSupplier, min, max);
+      LongPrecondition.checkRangeClosedOpen(ref.value(), exceptionSupplier, min, max);
       return ref;
     }
 
@@ -161,7 +161,7 @@ public interface LongValue<VO extends LongValue<VO>> extends SingleValue<Long> {
       if (isNull(ref)) {
         return null;
       }
-      LongPrecondition.checkRangeOpenClosed(ref.getValue(), exceptionSupplier, min, max);
+      LongPrecondition.checkRangeOpenClosed(ref.value(), exceptionSupplier, min, max);
       return ref;
     }
 
@@ -183,7 +183,7 @@ public interface LongValue<VO extends LongValue<VO>> extends SingleValue<Long> {
       if (isNull(ref)) {
         return null;
       }
-      LongPrecondition.checkAtLest(ref.getValue(), exceptionSupplier, min);
+      LongPrecondition.checkAtLest(ref.value(), exceptionSupplier, min);
       return ref;
     }
 
@@ -204,7 +204,7 @@ public interface LongValue<VO extends LongValue<VO>> extends SingleValue<Long> {
         return null;
       }
 
-      LongPrecondition.checkAtMost(ref.getValue(), exceptionSupplier, max);
+      LongPrecondition.checkAtMost(ref.value(), exceptionSupplier, max);
       return ref;
     }
 
@@ -224,7 +224,7 @@ public interface LongValue<VO extends LongValue<VO>> extends SingleValue<Long> {
       if (isNull(ref)) {
         return null;
       }
-      LongPrecondition.checkLessThan(ref.getValue(), exceptionSupplier, max);
+      LongPrecondition.checkLessThan(ref.value(), exceptionSupplier, max);
       return ref;
     }
 
@@ -245,7 +245,7 @@ public interface LongValue<VO extends LongValue<VO>> extends SingleValue<Long> {
         return ref;
       }
 
-      LongPrecondition.checkGreaterThan(ref.getValue(), exceptionSupplier, min);
+      LongPrecondition.checkGreaterThan(ref.value(), exceptionSupplier, min);
       return ref;
     }
 

--- a/backend/src/main/java/undecided/erp/common/entity/SingleValue.java
+++ b/backend/src/main/java/undecided/erp/common/entity/SingleValue.java
@@ -7,5 +7,5 @@ package undecided.erp.common.entity;
  */
 public interface SingleValue<T> extends ValueObject {
 
-  T getValue();
+  T value();
 }

--- a/backend/src/main/java/undecided/erp/common/entity/SnowflakeId.java
+++ b/backend/src/main/java/undecided/erp/common/entity/SnowflakeId.java
@@ -1,7 +1,9 @@
 package undecided.erp.common.entity;
 
+import static undecided.erp.common.precondition.LongPrecondition.checkPositive;
+import static undecided.erp.common.primitive.Objects2.isNull;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.collect.ComparisonChain;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
@@ -9,45 +11,34 @@ import java.beans.Transient;
 import java.io.Serial;
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import org.springframework.lang.Nullable;
-import static undecided.erp.common.precondition.LongPrecondition.checkPositive;
-import static undecided.erp.common.primitive.Objects2.isNull;
 import undecided.erp.common.snowflake.SnowflakeIdProvider;
 
 /**
  * SnowflakeIdクラスは、Snowflakeアルゴリズムによって生成される一意の長整数IDを表すクラスです。
  * IDをラップし、文字列表現や比較、データベースの永続化などのユーティリティメソッドを提供します。 このクラスは不変オブジェクトとして設計されています。
+ *
+ * <p>序列化・デシリアライズの過程でJSON形式で表現される際に利用されます。
  */
-@Getter
 @AllArgsConstructor
 @NoArgsConstructor(force = true)
-@EqualsAndHashCode
-public class SnowflakeId implements LongValue<SnowflakeId>,
-    Comparable<SnowflakeId>, Serializable {
-
+public class SnowflakeId implements LongValue<SnowflakeId>, Comparable<SnowflakeId>, Serializable {
   /**
    * 空のSnowflakeIdを表す定数。 この定数は、値を持たないSnowflakeIdオブジェクトを表現するために使用されます。 主に、未設定や初期状態を明示的に示すために利用されます。
-   * <p>
-   * 例外やエッジケースを処理する際に役立ち、空の状態であることを確認したり 比較や操作を実行する際の基準として使用されます。
+   *
+   * <p>例外やエッジケースを処理する際に役立ち、空の状態であることを確認したり 比較や操作を実行する際の基準として使用されます。
    */
   public static final SnowflakeId EMPTY = new SnowflakeId(null);
+
   /**
    * クラスSnowflakeIdにおいて、シリアライズのバージョン管理を行うために使用される直列化識別子。
    * serialVersionUIDは、異なるJava仮想マシン間でのインスタンスの保存および読み込み（シリアライズおよびデシリアライズ）
    * プロセス中に、クラスの互換性を検証するために使用されます。 クラスの構造に大きな変更がない限り、独自に定義された値を保持することで、 シリアライズ済みオブジェクトの互換性を維持ができます。
    */
-  @Serial
-  private static final long serialVersionUID = 1L;
-  /**
-   * SnowflakeIdインスタンスの基盤となる具体的な値を表します。 この値は不変であり、SnowflakeIdの一意性を保証するために使用されます。
-   * <p>
-   * 序列化・デシリアライズの過程でJSON形式で表現される際に利用されます。
-   */
-  @JsonValue
+  @Serial private static final long serialVersionUID = 1L;
+
   private final Long value;
 
   /**
@@ -102,7 +93,6 @@ public class SnowflakeId implements LongValue<SnowflakeId>,
   @Override
   public String toString() {
     return String.valueOf(value);
-
   }
 
   /**
@@ -121,7 +111,7 @@ public class SnowflakeId implements LongValue<SnowflakeId>,
    *
    * @param other 比較対象の SnowflakeId インスタンス。null の可能性があります。
    * @return この SnowflakeId が指定された SnowflakeId より小さい場合は負の整数、 等しい場合は 0、大きい場合は正の整数を返します。 指定されたオブジェクトが
-   * null の場合は -1 を返します。
+   *     null の場合は -1 を返します。
    */
   @Override
   public int compareTo(@Nullable SnowflakeId other) {
@@ -131,24 +121,25 @@ public class SnowflakeId implements LongValue<SnowflakeId>,
     if (isNull(this.value)) {
       return 1;
     }
-    return ComparisonChain
-        .start()
-        .compare(this.getValue(), other.getValue())
-        .result();
-
+    return ComparisonChain.start().compare(this.value(), other.value()).result();
   }
 
   /**
    * このインスタンスに格納されている値をBase-36エンコードされた文字列に変換します。
-   * <p>
-   * このメソッドは、変換を実行する前に値が空でないことを検証します。
+   *
+   * <p>このメソッドは、変換を実行する前に値が空でないことを検証します。
    *
    * @return 現在のインスタンスの値をBase-36エンコードした文字列。
    * @throws IllegalStateException 値がnullまたは空の場合にスローされます。
    */
   public String toBase36String() {
     LongValues.checkNotEmpty(this, () -> new IllegalStateException("value is empty"));
-    return Long.toString(getValue(), 36);
+    return Long.toString(value(), 36);
+  }
+
+  @Override
+  public Long value() {
+    return value;
   }
 
   /**
@@ -156,8 +147,7 @@ public class SnowflakeId implements LongValue<SnowflakeId>,
    * このクラスはJPAのAttributeConverterインターフェースを実装しています。
    */
   @Converter(autoApply = true)
-  public static class SnowflakeIdConverter implements
-      AttributeConverter<SnowflakeId, Long> {
+  public static class SnowflakeIdConverter implements AttributeConverter<SnowflakeId, Long> {
 
     /**
      * SnowflakeIdオブジェクトをデータベースに保存可能なLong型に変換します。
@@ -167,9 +157,7 @@ public class SnowflakeId implements LongValue<SnowflakeId>,
      */
     @Override
     public Long convertToDatabaseColumn(SnowflakeId attribute) {
-      return attribute != null ? attribute.getValue() : null;
-
-
+      return attribute != null ? attribute.value() : null;
     }
 
     /**

--- a/backend/src/main/java/undecided/erp/relationship/domain/model/party/SearchName.java
+++ b/backend/src/main/java/undecided/erp/relationship/domain/model/party/SearchName.java
@@ -66,6 +66,11 @@ public class SearchName implements StringValue<SearchName> {
     return Objects2.isNull(value);
   }
 
+  @Override
+  public String value() {
+    return value;
+  }
+
   /**
    * SearchNamePrefixCriteriaクラスは、特定の名前の接頭辞に基づく検索条件を表現するためのクラスです。
    *

--- a/backend/src/main/java/undecided/erp/scrum/presentation/api/sprint/SprintController.java
+++ b/backend/src/main/java/undecided/erp/scrum/presentation/api/sprint/SprintController.java
@@ -233,7 +233,7 @@ public class SprintController {
 
   private UserStoryResponse convertToUserStoryResponse(UserStory userStory) {
     UserStoryResponse response = new UserStoryResponse();
-    response.setStoryId(userStory.getStoryId().getValue());
+    response.setStoryId(userStory.getStoryId().value());
     response.setTitle(userStory.getTitle());
     response.setDescription(userStory.getDescription());
     response.setAcceptanceCriteria(userStory.getAcceptanceCriteria());

--- a/backend/src/test/java/undecided/erp/common/entity/SnowflakeIdTest.java
+++ b/backend/src/test/java/undecided/erp/common/entity/SnowflakeIdTest.java
@@ -55,7 +55,7 @@ class SnowflakeIdTest {
 
       // Assert
       assertThat(result).isNotNull();
-      assertThat(result.getValue()).isEqualTo(value);
+      assertThat(result.value()).isEqualTo(value);
     }
 
     @Test
@@ -108,7 +108,7 @@ class SnowflakeIdTest {
 
       // Assert
       assertThat(firstInstance).isNotEqualTo(secondInstance);
-      assertThat(firstInstance.getValue()).isNotEqualTo(secondInstance.getValue());
+      assertThat(firstInstance.value()).isNotEqualTo(secondInstance.value());
     }
   }
 
@@ -127,7 +127,7 @@ class SnowflakeIdTest {
 
       // Assert
       assertThat(result).isNotNull();
-      assertThat(result.getValue()).isEqualTo(value);
+      assertThat(result.value()).isEqualTo(value);
     }
 
     @Test


### PR DESCRIPTION
`getValue()`メソッドを`value()`にリネームし、一部関連コードを統一しました。これによりクラス間で命名規則が統一され、冗長な表記を削除して可読性を向上させました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 内部APIのアクセッサメソッド名を統一し、コード可読性を向上
  * 値オブジェクトのメソッドシグネチャを最適化

* **Tests**
  * 更新されたアクセッサメソッドに対応するテストを整備

<!-- end of auto-generated comment: release notes by coderabbit.ai -->