### PR TITLE
Add unit tests for `Longs` utility class

### DIFF
--- a/backend/src/main/java/undecided/erp/common/primitive/Longs.java
+++ b/backend/src/main/java/undecided/erp/common/primitive/Longs.java
@@ -2,6 +2,11 @@ package undecided.erp.common.primitive;
 
 import java.nio.ByteBuffer;
 
+/**
+ * {@code Long} 型の値を処理するユーティリティクラスです。 このクラスでは、長整数値をエンコードやバイト配列への変換といった操作をサポートします。
+ *
+ * <p>このクラスのメソッドはすべて静的であり、インスタンスを生成せずに使用します。
+ */
 public class Longs {
   /**
    * 指定された {@code longValue} を Base64 エンコード形式の文字列に変換します。

--- a/backend/src/main/java/undecided/erp/common/primitive/Longs.java
+++ b/backend/src/main/java/undecided/erp/common/primitive/Longs.java
@@ -1,0 +1,27 @@
+package undecided.erp.common.primitive;
+
+import java.nio.ByteBuffer;
+
+public class Longs {
+  /**
+   * 指定された {@code longValue} を Base64 エンコード形式の文字列に変換します。
+   *
+   * @param longValue エンコード対象となる {@code Long} 型の値
+   * @return {@code longValue} を Base64 エンコードした文字列
+   */
+  public static String encodeToBase64(Long longValue) {
+    return java.util.Base64.getUrlEncoder().encodeToString(Longs.toByteArray(longValue));
+  }
+
+  /**
+   * 指定された {@code Long} 型の値を {@code byte[]} 配列に変換します。
+   *
+   * @param longValue 変換対象となる {@code Long} 型の値
+   * @return 指定された値を表現する8バイトの {@code byte[]} 配列
+   */
+  static byte[] toByteArray(Long longValue) {
+    ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+    buffer.putLong(longValue);
+    return buffer.array();
+  }
+}

--- a/backend/src/main/java/undecided/erp/common/primitive/Longs.java
+++ b/backend/src/main/java/undecided/erp/common/primitive/Longs.java
@@ -1,12 +1,14 @@
 package undecided.erp.common.primitive;
 
 import java.nio.ByteBuffer;
+import lombok.experimental.UtilityClass;
 
 /**
  * {@code Long} 型の値を処理するユーティリティクラスです。 このクラスでは、長整数値をエンコードやバイト配列への変換といった操作をサポートします。
  *
  * <p>このクラスのメソッドはすべて静的であり、インスタンスを生成せずに使用します。
  */
+@UtilityClass
 public class Longs {
   /**
    * 指定された {@code longValue} を Base64 エンコード形式の文字列に変換します。

--- a/backend/src/test/java/undecided/erp/common/primitive/LongsTest.java
+++ b/backend/src/test/java/undecided/erp/common/primitive/LongsTest.java
@@ -1,0 +1,85 @@
+package undecided.erp.common.primitive;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/** Test class for the {@link Longs#encodeToBase64(Long)} method. */
+class LongsTest {
+
+  @Nested
+  @DisplayName("encodeToBase64メソッドのテスト")
+  class EncodeToBase64Test {
+
+    @Test
+    @DisplayName("正のLong値をエンコードしたBase64形式の文字列を返す")
+    void shouldReturnBase64EncodedStringForPositiveLong() {
+      Long input = 123456789L;
+      String result = Longs.encodeToBase64(input);
+      assertThat(result).isEqualTo("AAAAAAdbzRU=");
+    }
+
+    @Test
+    @DisplayName("負のLong値をエンコードしたBase64形式の文字列を返す")
+    void shouldReturnBase64EncodedStringForNegativeLong() {
+      Long input = -123456789L;
+      String result = Longs.encodeToBase64(input);
+      assertThat(result).isEqualTo("______ikMus=");
+    }
+
+    @Test
+    @DisplayName("0をエンコードしたBase64形式の文字列を返す")
+    void shouldReturnBase64EncodedStringForZero() {
+      Long input = 0L;
+      String result = Longs.encodeToBase64(input);
+      assertThat(result).isEqualTo("AAAAAAAAAAA=");
+    }
+
+    @Test
+    @DisplayName("Long値がnullの場合に例外をスローする")
+    void shouldThrowExceptionWhenLongValueIsNull() {
+      Long input = null;
+      assertThatThrownBy(() -> Longs.encodeToBase64(input))
+          .isInstanceOf(NullPointerException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("toByteArrayメソッドのテスト")
+  class ToByteArrayTest {
+
+    @Test
+    @DisplayName("正のLong値をbyte配列に変換する")
+    void shouldConvertPositiveLongToByteArray() {
+      Long input = 123456789L;
+      byte[] result = Longs.toByteArray(input);
+      assertThat(result).containsExactly(0, 0, 0, 0, 7, 91, -51, 21);
+    }
+
+    @Test
+    @DisplayName("負のLong値をbyte配列に変換する")
+    void shouldConvertNegativeLongToByteArray() {
+      Long input = -123456789L;
+      byte[] result = Longs.toByteArray(input);
+      assertThat(result).containsExactly(-1, -1, -1, -1, -8, -92, 50, -21);
+    }
+
+    @Test
+    @DisplayName("0をbyte配列に変換する")
+    void shouldConvertZeroToByteArray() {
+      Long input = 0L;
+      byte[] result = Longs.toByteArray(input);
+      assertThat(result).containsExactly(0, 0, 0, 0, 0, 0, 0, 0);
+    }
+
+    @Test
+    @DisplayName("Long値がnullの場合に例外をスローする")
+    void shouldThrowExceptionWhenLongValueIsNull() {
+      Long input = null;
+      assertThatThrownBy(() -> Longs.toByteArray(input)).isInstanceOf(NullPointerException.class);
+    }
+  }
+}


### PR DESCRIPTION
### Description

This pull request adds unit tests for the `Longs` utility class. Tests cover the `encodeToBase64` and `toByteArray` methods, ensuring functionality for positive values, negative values, zero, and exception handling cases.

### Related Issues

- refs: #52

### Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code where relevant.
- [x] I have ensured that new and existing unit tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Long値をURLセーフなBase64文字列に変換するユーティリティ機能を追加しました。

* **テスト**
  * 正負およびゼロの値、ならびにnull入力を含む包括的なテストスイートを導入し、変換処理の正当性を検証しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->