### PR TITLE
Add `decodeFromBase64` method with unit tests to `Longs`

### DIFF
--- a/backend/src/main/java/undecided/erp/common/primitive/Longs.java
+++ b/backend/src/main/java/undecided/erp/common/primitive/Longs.java
@@ -41,6 +41,10 @@ public class Longs {
   public static Long decodeFromBase64(String base64String) {
     byte[] decodedBytes = java.util.Base64.getUrlDecoder().decode(base64String);
     ByteBuffer buffer = ByteBuffer.wrap(decodedBytes);
+    if (decodedBytes.length != Long.BYTES) {
+      throw new IllegalArgumentException(
+          "デコードされたバイト配列の長さが不正です。期待値: " + Long.BYTES + "バイト、実際: " + decodedBytes.length + "バイト");
+    }
     return buffer.getLong();
   }
 }

--- a/backend/src/main/java/undecided/erp/common/primitive/Longs.java
+++ b/backend/src/main/java/undecided/erp/common/primitive/Longs.java
@@ -31,4 +31,16 @@ public class Longs {
     buffer.putLong(longValue);
     return buffer.array();
   }
+
+  /**
+   * 指定された Base64 エンコード形式の文字列をデコードし、{@code Long} 型の値に変換します。
+   *
+   * @param base64String デコード対象となる Base64 エンコード形式の文字列
+   * @return デコードされた {@code Long} 型の値
+   */
+  public static Long decodeFromBase64(String base64String) {
+    byte[] decodedBytes = java.util.Base64.getUrlDecoder().decode(base64String);
+    ByteBuffer buffer = ByteBuffer.wrap(decodedBytes);
+    return buffer.getLong();
+  }
 }

--- a/backend/src/test/java/undecided/erp/common/primitive/LongsTest.java
+++ b/backend/src/test/java/undecided/erp/common/primitive/LongsTest.java
@@ -118,5 +118,32 @@ class LongsTest {
       assertThatThrownBy(() -> Longs.decodeFromBase64(input))
           .isInstanceOf(NullPointerException.class);
     }
+
+    @Test
+    @DisplayName("無効なBase64形式文字列の場合、例外をスローする")
+    void shouldThrowExceptionForInvalidBase64String() {
+      String input = "InvalidBase64";
+      assertThatThrownBy(() -> Longs.decodeFromBase64(input))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Illegal base64 character");
+    }
+
+    @Test
+    @DisplayName("空のBase64文字列の場合、例外をスローする")
+    void shouldThrowExceptionForEmptyBase64String() {
+      String input = "";
+      assertThatThrownBy(() -> Longs.decodeFromBase64(input))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("デコードされたバイト配列の長さが不正です");
+    }
+
+    @Test
+    @DisplayName("Base64文字列の長さが不正の場合、例外をスローする")
+    void shouldThrowExceptionForIncorrectLengthBase64String() {
+      String input = "AAA="; // Incorrect length
+      assertThatThrownBy(() -> Longs.decodeFromBase64(input))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("デコードされたバイト配列の長さが不正です");
+    }
   }
 }

--- a/backend/src/test/java/undecided/erp/common/primitive/LongsTest.java
+++ b/backend/src/test/java/undecided/erp/common/primitive/LongsTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-/** Test class for the {@link Longs#encodeToBase64(Long)} method. */
+/** LongsTest クラスのテストケースを定義したクラスです。 Long 型の値に対するエンコードや変換に関連するユーティリティメソッドの動作を検証します。 */
 class LongsTest {
 
   @Nested
@@ -80,6 +80,43 @@ class LongsTest {
     void shouldThrowExceptionWhenLongValueIsNull() {
       Long input = null;
       assertThatThrownBy(() -> Longs.toByteArray(input)).isInstanceOf(NullPointerException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("decodeFromBase64メソッドのテスト")
+  class DecodeFromBase64Test {
+
+    @Test
+    @DisplayName("有効な正のBase64形式文字列から対応するLong値を返す")
+    void shouldReturnCorrectPositiveLongForBase64() {
+      String input = "AAAAAAdbzRU=";
+      Long result = Longs.decodeFromBase64(input);
+      assertThat(result).isEqualTo(123456789L);
+    }
+
+    @Test
+    @DisplayName("有効な負のBase64形式文字列から対応するLong値を返す")
+    void shouldReturnCorrectNegativeLongForBase64() {
+      String input = "______ikMus=";
+      Long result = Longs.decodeFromBase64(input);
+      assertThat(result).isEqualTo(-123456789L);
+    }
+
+    @Test
+    @DisplayName("0に対応するBase64形式文字列からLong値0を返す")
+    void shouldReturnZeroForBase64String() {
+      String input = "AAAAAAAAAAA=";
+      Long result = Longs.decodeFromBase64(input);
+      assertThat(result).isEqualTo(0L);
+    }
+
+    @Test
+    @DisplayName("Base64形式文字列がnullの場合、例外をスローする")
+    void shouldThrowExceptionWhenBase64StringIsNull() {
+      String input = null;
+      assertThatThrownBy(() -> Longs.decodeFromBase64(input))
+          .isInstanceOf(NullPointerException.class);
     }
   }
 }


### PR DESCRIPTION
### Summary
This pull request introduces the `decodeFromBase64` method to the `Longs` class, enabling decoding of Base64-encoded strings into `Long` type values. Additionally, comprehensive unit tests for this method are added to ensure reliability and proper handling of various cases, including positive and negative values, zero, and null inputs.

### Changes
- Introduced the `decodeFromBase64` method in the `Longs` class.
- Added unit tests to validate different decoding scenarios and error handling.

### Checklist
- [x] Unit tests have been added or updated.
- [x] Documentation has been updated if applicable.  

fixsed: #53


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Base64形式の文字列を64ビット整数にデコードする機能を追加しました。

* **テスト**
  * 正常値（正・負・ゼロ）、null、無効なBase64、空文字、長さ不一致などを含む包括的なテストケースを追加しました。

* **ドキュメント**
  * テストクラスのJavadocを日本語に更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->