### PR TITLE
Add global exception handling and unit tests

### DIFF
--- a/backend/src/main/java/undecided/erp/shared/presentation/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/undecided/erp/shared/presentation/exception/GlobalExceptionHandler.java
@@ -25,7 +25,7 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(Exception.class)
   public ResponseEntity<Map<String, Object>> handleException(Exception e) {
     Map<String, Object> error = new HashMap<>();
-    error.put(" error", e.getMessage());
+    error.put("error", e.getMessage());
     return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
   }
 }

--- a/backend/src/main/java/undecided/erp/shared/presentation/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/undecided/erp/shared/presentation/exception/GlobalExceptionHandler.java
@@ -1,0 +1,31 @@
+package undecided.erp.shared.presentation.exception;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * アプリケーション全体で発生する例外をハンドリングするクラス。
+ *
+ * <p>Spring Boot の @RestControllerAdvice アノテーションを使用しており、 グローバル例外処理を提供します。
+ *
+ * <p>主に、予期しない例外をキャッチし、適切なエラーレスポンスをクライアントに返却します。
+ */
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+  /**
+   * 例外を処理し、HTTPレスポンスとしてエラーメッセージを返却します。
+   *
+   * @param e 処理中に発生した例外
+   * @return 内部サーバエラー (500) ステータスコードとエラーメッセージを含むレスポンスエンティティ
+   */
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<Map<String, Object>> handleException(Exception e) {
+    Map<String, Object> error = new HashMap<>();
+    error.put(" error", e.getMessage());
+    return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(error);
+  }
+}

--- a/backend/src/main/java/undecided/erp/shared/presentation/exception/package-info.java
+++ b/backend/src/main/java/undecided/erp/shared/presentation/exception/package-info.java
@@ -1,0 +1,1 @@
+package undecided.erp.shared.presentation.exception;

--- a/backend/src/main/java/undecided/erp/shared/presentation/package-info.java
+++ b/backend/src/main/java/undecided/erp/shared/presentation/package-info.java
@@ -1,0 +1,1 @@
+package undecided.erp.shared.presentation;

--- a/backend/src/test/java/undecided/erp/shared/presentation/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/undecided/erp/shared/presentation/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,46 @@
+package undecided.erp.shared.presentation.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.WebApplicationContext;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@DisplayName("GlobalExceptionHandlerの単体テスト")
+class GlobalExceptionHandlerTest {
+
+  @Autowired private WebApplicationContext context;
+
+  @Nested
+  @DisplayName("handleExceptionメソッドのテスト")
+  class HandleExceptionTests {
+
+    @Test
+    @DisplayName("例外が投げられた場合、エラーレスポンスを返却する")
+    void shouldReturnErrorResponseWhenExceptionIsThrown() {
+      // Arrange
+      GlobalExceptionHandler globalExceptionHandler = new GlobalExceptionHandler();
+      Exception exception = new Exception("サーバーでエラーが発生しました");
+
+      // Act
+      ResponseEntity<Map<String, Object>> response =
+          globalExceptionHandler.handleException(exception);
+
+      // Assert
+      assertThat(response).isNotNull();
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+      assertThat(response.getBody()).isNotNull();
+      assertThat(response.getBody()).containsKey(" error");
+      assertThat(response.getBody().get(" error")).isEqualTo("サーバーでエラーが発生しました");
+    }
+  }
+}

--- a/backend/src/test/java/undecided/erp/shared/presentation/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/undecided/erp/shared/presentation/exception/GlobalExceptionHandlerTest.java
@@ -40,7 +40,7 @@ class GlobalExceptionHandlerTest {
       assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
       assertThat(response.getBody()).isNotNull();
       assertThat(response.getBody()).containsKey(" error");
-      assertThat(response.getBody().get(" error")).isEqualTo("サーバーでエラーが発生しました");
+      assertThat(response.getBody().get("error")).isEqualTo("サーバーでエラーが発生しました");
     }
   }
 }

--- a/backend/src/test/java/undecided/erp/shared/presentation/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/undecided/erp/shared/presentation/exception/GlobalExceptionHandlerTest.java
@@ -39,7 +39,7 @@ class GlobalExceptionHandlerTest {
       assertThat(response).isNotNull();
       assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
       assertThat(response.getBody()).isNotNull();
-      assertThat(response.getBody()).containsKey(" error");
+      assertThat(response.getBody()).containsKey("error");
       assertThat(response.getBody().get("error")).isEqualTo("サーバーでエラーが発生しました");
     }
   }


### PR DESCRIPTION
### Description

This pull request introduces a new `GlobalExceptionHandler` to the shared module, enabling centralized exception handling across the application. Additionally, unit tests for `GlobalExceptionHandler` have been added to ensure correctness and reliability of error handling functionality.

### Changes
- Added `GlobalExceptionHandler` class to manage exceptions and return appropriate error responses.
- Implemented unit tests to validate the behavior of `GlobalExceptionHandler`.

### Checklist

- [x] Code has been reviewed
- [x] Unit tests have been added
- [x] Documentation has been updated if necessary
- fix: #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 未捕捉の例外発生時にグローバルに一貫したサーバーエラーレスポンスを返すよう改善しました（HTTP 500 とエラーメッセージを含む）。

* **テスト**
  * 上記エラーハンドリングの単体テストを追加し、期待されるレスポンス本文とステータスを検証しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->