### PR TITLE
Add tests for RoleChangeRequestType behavior

### DIFF
--- a/TEST_GENERATION_SUMMARY.md
+++ b/TEST_GENERATION_SUMMARY.md
@@ -1,0 +1,137 @@
+# Unit Test Generation Summary
+
+## Overview
+Generated comprehensive unit tests for `RoleChangeRequestType` enum class in the ERP role module.
+
+## Files Modified
+- **Test File**: `backend/src/test/java/undecided/erp/role/RoleChangeRequestTypeTest.java`
+- **Original Lines**: 94
+- **Final Lines**: 598
+- **Tests Added**: 39 new test methods (total: 45 tests)
+- **Nested Test Classes Added**: 5 new nested classes (total: 6 nested classes)
+
+## Test Coverage Added
+
+### 1. GetCodeTest (4 tests)
+Tests for the `getCode()` method to ensure each enum constant returns the correct code:
+- CREATE returns "00"
+- UPDATE returns "10"
+- DELETE returns "20"
+- UNKNOWN returns "00"
+
+**Critical Finding**: These tests will FAIL because they expose a bug in the source code where the enum constants have codes ("00", "10", "20") that don't match the switch statement in `valueOfCode()` (which expects "10", "20", "30").
+
+### 2. GetSortOrderTest (5 tests)
+Tests for the `getSortOrder()` method:
+- Validates correct sort order for each enum constant (UPDATE=10, CREATE=20, DELETE=30, UNKNOWN=999)
+- Tests sorting functionality to ensure enums can be ordered by their sortOrder field
+- Verifies the expected sort order: UPDATE < CREATE < DELETE < UNKNOWN
+
+### 3. ValueOfCodeAdditionalTest (10 tests)
+Extended tests for `valueOfCode()` method covering edge cases:
+- Round-trip testing: Ensures `valueOfCode(enum.getCode())` returns the original enum
+- Tests for code "00" (overlaps with CREATE and UNKNOWN codes)
+- Whitespace handling (leading/trailing spaces should not be trimmed)
+- Non-numeric characters
+- Negative numbers
+- Very long strings
+- Single digit codes
+- Empty strings
+
+**Critical Finding**: The round-trip tests will FAIL for CREATE, UPDATE, and DELETE due to the code mismatch bug.
+
+### 4. JacksonSerializationTest (13 tests)
+Comprehensive Jackson JSON serialization/deserialization tests:
+- Serialization tests: Verify each enum serializes to its code value via `@JsonValue`
+- Deserialization tests: Verify JSON codes deserialize to correct enums via `@JsonCreator`
+- Null handling: Ensures null JSON throws appropriate exception
+- Round-trip tests: Validates serialization → deserialization produces the original enum
+- Tests for invalid codes during deserialization
+
+**Critical Finding**: Round-trip serialization tests will FAIL for CREATE, UPDATE, and DELETE due to the code mismatch.
+
+### 5. EnumBasicFunctionalityTest (7 tests)
+Tests for standard Java enum functionality:
+- `values()`: Returns all 4 enum constants in order
+- `valueOf(String)`: Retrieves enum by name
+- `name()`: Returns enum constant name
+- `ordinal()`: Returns correct index (0-3)
+- `toString()`: Returns enum name
+- `compareTo()`: Compares enums by ordinal
+- Equality testing: Validates enum singleton pattern (== operator)
+
+## Test Framework & Tools Used
+- **Test Framework**: JUnit 5 (Jupiter)
+- **Assertion Library**: AssertJ
+- **JSON Processing**: Jackson ObjectMapper
+- **Test Organization**: Nested test classes with descriptive Japanese DisplayName annotations
+- **Test Pattern**: Arrange-Act-Assert (AAA) pattern
+
+## Key Testing Principles Applied
+1. **Comprehensive Coverage**: Tests cover happy paths, edge cases, and error conditions
+2. **Pure Function Testing**: Focus on pure methods (getCode, getSortOrder)
+3. **Boundary Testing**: Tests edge cases like null, empty strings, whitespace, special characters
+4. **Round-trip Testing**: Validates bidirectional conversions (code ↔ enum, JSON ↔ enum)
+5. **Descriptive Naming**: Clear Japanese DisplayName annotations explain test intent
+6. **Code Consistency**: Follows existing test patterns in the project (AAA pattern, nested classes)
+
+## Critical Bug Discovered
+The comprehensive tests reveal a **critical bug** in the source code:
+
+**Issue**: Mismatch between enum constant codes and the `valueOfCode()` switch statement
+
+```java
+// Enum constants have these codes:
+CREATE("00", 20)   // code = "00"
+UPDATE("10", 10)   // code = "10"
+DELETE("20", 30)   // code = "20"
+
+// But valueOfCode() expects these codes:
+case "10" -> CREATE  // expects "10" but CREATE has "00"
+case "20" -> UPDATE  // expects "20" but UPDATE has "10"
+case "30" -> DELETE  // expects "30" but DELETE has "20"
+```
+
+**Impact**: 
+- Serialization works (uses getCode())
+- Deserialization fails (uses valueOfCode())
+- Round-trip JSON serialization/deserialization will fail for CREATE, UPDATE, DELETE
+- Only UNKNOWN works correctly as it uses the default case
+
+**Recommended Fix**: Update either the enum constructor codes OR the switch cases in valueOfCode() to match:
+
+Option 1 - Fix enum codes to match switch:
+```java
+CREATE("10", 20)
+UPDATE("20", 10)
+DELETE("30", 30)
+```
+
+Option 2 - Fix switch to match enum codes:
+```java
+case "00" -> CREATE
+case "10" -> UPDATE
+case "20" -> DELETE
+```
+
+## Test Execution
+To run these tests:
+```bash
+cd backend
+./gradlew test --tests "undecided.erp.role.RoleChangeRequestTypeTest"
+```
+
+Expected result: **Several tests will FAIL** due to the code mismatch bug described above. This is intentional - the tests expose real bugs.
+
+## Value Provided
+1. **Bug Detection**: Discovered critical code/switch mismatch that would cause runtime failures
+2. **Comprehensive Coverage**: 45 tests covering all public methods and edge cases
+3. **Documentation**: Tests serve as living documentation of expected behavior
+4. **Regression Prevention**: Future changes will be validated against this test suite
+5. **JSON Contract Validation**: Ensures Jackson serialization works correctly for API contracts
+
+## Next Steps
+1. Fix the code mismatch bug in the source code
+2. Run tests to verify the fix
+3. Consider adding integration tests for database persistence if this enum is persisted
+4. Add parameterized tests if similar enums are added in the future

--- a/backend/src/main/java/undecided/erp/role/RoleChangeRequestType.java
+++ b/backend/src/main/java/undecided/erp/role/RoleChangeRequestType.java
@@ -1,0 +1,79 @@
+package undecided.erp.role;
+
+import static undecided.erp.common.precondition.ObjectPrecondition.checkNotNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.jspecify.annotations.NonNull;
+
+/**
+ * RoleChangeRequestTypeは、ロール変更要求の種類を表す列挙型です。 この列挙型は、コードおよびソート順に基づいて異なるタイプのロール変更を識別します。
+ *
+ * <p>各種類には以下のフィールドが設定されています: - code: 種類を識別するコード - sortOrder: 種類のソート順を表す数値
+ *
+ * <p>使用される種類: - C: 作成（コード: "00"、ソート順: 20） - UPDATE: 更新（コード: "10"、ソート順: 10） - DELETE: 削除（コード:
+ * "20"、ソート順: 30） - UNKNOWN: 未定義または不明（コード: "00"、ソート順: 999）
+ */
+public enum RoleChangeRequestType {
+  /** CREATEは、新しいロール変更要求の作成を表します。 この種類は、コード"00"およびソート順20として識別されます。 */
+  CREATE("00", 20),
+  /** UPDATEは、既存のロール変更要求の更新を表します。 この種類は、コード"10"およびソート順10として識別されます。 */
+  UPDATE("10", 10),
+  /** DELETEは、既存のロール変更要求の削除を表します。 この種類は、コード"20"およびソート順30として識別されます。 */
+  DELETE("20", 30),
+  /** UNKNOWNは、未定義または不明なロール変更要求の種類を表します。 この種類は、コード"00"およびソート順999として識別されます。 */
+  UNKNOWN("00", 999);
+
+  private final int sortOrder;
+  private final String code;
+
+  /**
+   * 指定されたコードおよびソート順を使用してRoleChangeRequestType列挙型のインスタンスを初期化します。
+   *
+   * @param code 種類を識別するためのコード
+   * @param sortOrder 種類のソート順を示す数値
+   */
+  RoleChangeRequestType(String code, int sortOrder) {
+    this.code = code;
+    this.sortOrder = sortOrder;
+  }
+
+  /**
+   * 指定されたコードに基づいてRoleChangeRequestTypeを評価し、対応する列挙型を返します。
+   *
+   * <p>コードが無効な場合はUNKNOWNを返します。
+   *
+   * @param code ロール変更要求の種類を識別するためのコード（必須）
+   * @return 指定されたコードに対応するRoleChangeRequestType列挙型。 コードに対応する値が存在しない場合はUNKNOWNを返します。
+   * @throws IllegalArgumentException 引数codeがnullの場合
+   */
+  @JsonCreator
+  public static RoleChangeRequestType valueOfCode(@NonNull String code) {
+    checkNotNull(code, () -> new IllegalArgumentException("code must not be null."));
+    return switch (code) {
+      case "10" -> CREATE;
+      case "20" -> UPDATE;
+      case "30" -> DELETE;
+      default -> UNKNOWN;
+    };
+  }
+
+  /**
+   * このメソッドは、RoleChangeRequestTypeを識別するコードを取得します。
+   *
+   * @return このRoleChangeRequestTypeに関連付けられた識別コード
+   */
+  @JsonValue
+  public String getCode() {
+    return code;
+  }
+
+  /**
+   * このメソッドは、RoleChangeRequestTypeのソート順を取得します。
+   *
+   * @return このRoleChangeRequestTypeに関連付けられたソート順の数値
+   */
+  public int getSortOrder() {
+    return sortOrder;
+  }
+}

--- a/backend/src/main/java/undecided/erp/role/RoleChangeRequestType.java
+++ b/backend/src/main/java/undecided/erp/role/RoleChangeRequestType.java
@@ -28,10 +28,10 @@ public enum RoleChangeRequestType {
   private final String code;
 
   /**
-   * 指定されたコードおよびソート順を使用してRoleChangeRequestType列挙型のインスタンスを初期化します。
+   * Initialize this enum constant with its external code and display order.
    *
-   * @param code 種類を識別するためのコード
-   * @param sortOrder 種類のソート順を示す数値
+   * @param code      the string code that identifies the request type
+   * @param sortOrder the numeric sort order used when ordering request types
    */
   RoleChangeRequestType(String code, int sortOrder) {
     this.code = code;
@@ -39,13 +39,11 @@ public enum RoleChangeRequestType {
   }
 
   /**
-   * 指定されたコードに基づいてRoleChangeRequestTypeを評価し、対応する列挙型を返します。
+   * Map a code string to its corresponding RoleChangeRequestType.
    *
-   * <p>コードが無効な場合はUNKNOWNを返します。
-   *
-   * @param code ロール変更要求の種類を識別するためのコード（必須）
-   * @return 指定されたコードに対応するRoleChangeRequestType列挙型。 コードに対応する値が存在しない場合はUNKNOWNを返します。
-   * @throws IllegalArgumentException 引数codeがnullの場合
+   * @param code the code identifying the role change request type
+   * @return the matching RoleChangeRequestType; `UNKNOWN` if the code is not recognized
+   * @throws IllegalArgumentException if `code` is null
    */
   @JsonCreator
   public static RoleChangeRequestType valueOfCode(@NonNull String code) {
@@ -59,9 +57,9 @@ public enum RoleChangeRequestType {
   }
 
   /**
-   * このメソッドは、RoleChangeRequestTypeを識別するコードを取得します。
+   * Provides the identifier code for this role change request type.
    *
-   * @return このRoleChangeRequestTypeに関連付けられた識別コード
+   * @return the identifier code associated with this enum constant
    */
   @JsonValue
   public String getCode() {
@@ -69,9 +67,9 @@ public enum RoleChangeRequestType {
   }
 
   /**
-   * このメソッドは、RoleChangeRequestTypeのソート順を取得します。
+   * The numeric sort order associated with this role change request type.
    *
-   * @return このRoleChangeRequestTypeに関連付けられたソート順の数値
+   * @return the sort order value for this enum constant
    */
   public int getSortOrder() {
     return sortOrder;

--- a/backend/src/test/java/undecided/erp/role/RoleChangeRequestTypeTest.java
+++ b/backend/src/test/java/undecided/erp/role/RoleChangeRequestTypeTest.java
@@ -91,4 +91,508 @@ class RoleChangeRequestTypeTest {
       assertThat(result).isEqualTo(RoleChangeRequestType.UNKNOWN);
     }
   }
+
+  @Nested
+  @DisplayName("getCodeメソッドのテスト")
+  class GetCodeTest {
+
+    @Test
+    @DisplayName("CREATEのコードは'00'であるべき")
+    void shouldReturnCorrectCodeForCreate() {
+      // Act
+      String code = RoleChangeRequestType.CREATE.getCode();
+
+      // Assert
+      assertThat(code).isEqualTo("00");
+    }
+
+    @Test
+    @DisplayName("UPDATEのコードは'10'であるべき")
+    void shouldReturnCorrectCodeForUpdate() {
+      // Act
+      String code = RoleChangeRequestType.UPDATE.getCode();
+
+      // Assert
+      assertThat(code).isEqualTo("10");
+    }
+
+    @Test
+    @DisplayName("DELETEのコードは'20'であるべき")
+    void shouldReturnCorrectCodeForDelete() {
+      // Act
+      String code = RoleChangeRequestType.DELETE.getCode();
+
+      // Assert
+      assertThat(code).isEqualTo("20");
+    }
+
+    @Test
+    @DisplayName("UNKNOWNのコードは'00'であるべき")
+    void shouldReturnCorrectCodeForUnknown() {
+      // Act
+      String code = RoleChangeRequestType.UNKNOWN.getCode();
+
+      // Assert
+      assertThat(code).isEqualTo("00");
+    }
+  }
+
+  @Nested
+  @DisplayName("getSortOrderメソッドのテスト")
+  class GetSortOrderTest {
+
+    @Test
+    @DisplayName("CREATEのソート順は20であるべき")
+    void shouldReturnCorrectSortOrderForCreate() {
+      // Act
+      int sortOrder = RoleChangeRequestType.CREATE.getSortOrder();
+
+      // Assert
+      assertThat(sortOrder).isEqualTo(20);
+    }
+
+    @Test
+    @DisplayName("UPDATEのソート順は10であるべき")
+    void shouldReturnCorrectSortOrderForUpdate() {
+      // Act
+      int sortOrder = RoleChangeRequestType.UPDATE.getSortOrder();
+
+      // Assert
+      assertThat(sortOrder).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("DELETEのソート順は30であるべき")
+    void shouldReturnCorrectSortOrderForDelete() {
+      // Act
+      int sortOrder = RoleChangeRequestType.DELETE.getSortOrder();
+
+      // Assert
+      assertThat(sortOrder).isEqualTo(30);
+    }
+
+    @Test
+    @DisplayName("UNKNOWNのソート順は999であるべき")
+    void shouldReturnCorrectSortOrderForUnknown() {
+      // Act
+      int sortOrder = RoleChangeRequestType.UNKNOWN.getSortOrder();
+
+      // Assert
+      assertThat(sortOrder).isEqualTo(999);
+    }
+
+    @Test
+    @DisplayName("ソート順でソートした場合、UPDATE < CREATE < DELETE < UNKNOWNの順序になるべき")
+    void shouldSortEnumsBySortOrder() {
+      // Arrange
+      java.util.List<RoleChangeRequestType> types = java.util.Arrays.asList(
+          RoleChangeRequestType.UNKNOWN,
+          RoleChangeRequestType.DELETE,
+          RoleChangeRequestType.CREATE,
+          RoleChangeRequestType.UPDATE
+      );
+
+      // Act
+      java.util.List<RoleChangeRequestType> sorted = types.stream()
+          .sorted(java.util.Comparator.comparingInt(RoleChangeRequestType::getSortOrder))
+          .toList();
+
+      // Assert
+      assertThat(sorted).containsExactly(
+          RoleChangeRequestType.UPDATE,
+          RoleChangeRequestType.CREATE,
+          RoleChangeRequestType.DELETE,
+          RoleChangeRequestType.UNKNOWN
+      );
+    }
+  }
+
+  @Nested
+  @DisplayName("valueOfCodeメソッドの追加テスト")
+  class ValueOfCodeAdditionalTest {
+
+    @Test
+    @DisplayName("valueOfCodeで取得したenumのgetCodeが元のcodeと一致すべき（CREATE）")
+    void shouldRoundTripCodeForCreate() {
+      // Arrange
+      String originalCode = RoleChangeRequestType.CREATE.getCode();
+
+      // Act
+      RoleChangeRequestType result = RoleChangeRequestType.valueOfCode(originalCode);
+
+      // Assert
+      assertThat(result).isEqualTo(RoleChangeRequestType.CREATE);
+      assertThat(result.getCode()).isEqualTo(originalCode);
+    }
+
+    @Test
+    @DisplayName("valueOfCodeで取得したenumのgetCodeが元のcodeと一致すべき（UPDATE）")
+    void shouldRoundTripCodeForUpdate() {
+      // Arrange
+      String originalCode = RoleChangeRequestType.UPDATE.getCode();
+
+      // Act
+      RoleChangeRequestType result = RoleChangeRequestType.valueOfCode(originalCode);
+
+      // Assert
+      assertThat(result).isEqualTo(RoleChangeRequestType.UPDATE);
+      assertThat(result.getCode()).isEqualTo(originalCode);
+    }
+
+    @Test
+    @DisplayName("valueOfCodeで取得したenumのgetCodeが元のcodeと一致すべき（DELETE）")
+    void shouldRoundTripCodeForDelete() {
+      // Arrange
+      String originalCode = RoleChangeRequestType.DELETE.getCode();
+
+      // Act
+      RoleChangeRequestType result = RoleChangeRequestType.valueOfCode(originalCode);
+
+      // Assert
+      assertThat(result).isEqualTo(RoleChangeRequestType.DELETE);
+      assertThat(result.getCode()).isEqualTo(originalCode);
+    }
+
+    @Test
+    @DisplayName("valueOfCodeで取得したenumのgetCodeが元のcodeと一致すべき（UNKNOWN）")
+    void shouldRoundTripCodeForUnknown() {
+      // Arrange
+      String originalCode = RoleChangeRequestType.UNKNOWN.getCode();
+
+      // Act
+      RoleChangeRequestType result = RoleChangeRequestType.valueOfCode(originalCode);
+
+      // Assert
+      assertThat(result.getCode()).isEqualTo(originalCode);
+    }
+
+    @Test
+    @DisplayName("codeが'00'の場合、UNKNOWNが返されるべき（CREATEのコードと同じだが、デフォルトケースとして扱われる）")
+    void shouldReturnUnknownWhenCodeIs00() {
+      // Arrange
+      String code = "00";
+
+      // Act
+      RoleChangeRequestType result = RoleChangeRequestType.valueOfCode(code);
+
+      // Assert
+      assertThat(result).isEqualTo(RoleChangeRequestType.UNKNOWN);
+    }
+
+    @Test
+    @DisplayName("codeに先頭と末尾の空白がある場合、トリムされずにUNKNOWNが返されるべき")
+    void shouldReturnUnknownWhenCodeHasWhitespace() {
+      // Arrange
+      String code = " 10 ";
+
+      // Act
+      RoleChangeRequestType result = RoleChangeRequestType.valueOfCode(code);
+
+      // Assert
+      assertThat(result).isEqualTo(RoleChangeRequestType.UNKNOWN);
+    }
+
+    @Test
+    @DisplayName("codeが数値以外の文字を含む場合、UNKNOWNが返されるべき")
+    void shouldReturnUnknownWhenCodeContainsNonNumericCharacters() {
+      // Arrange
+      String code = "1a";
+
+      // Act
+      RoleChangeRequestType result = RoleChangeRequestType.valueOfCode(code);
+
+      // Assert
+      assertThat(result).isEqualTo(RoleChangeRequestType.UNKNOWN);
+    }
+
+    @Test
+    @DisplayName("codeが負の数の場合、UNKNOWNが返されるべき")
+    void shouldReturnUnknownWhenCodeIsNegative() {
+      // Arrange
+      String code = "-10";
+
+      // Act
+      RoleChangeRequestType result = RoleChangeRequestType.valueOfCode(code);
+
+      // Assert
+      assertThat(result).isEqualTo(RoleChangeRequestType.UNKNOWN);
+    }
+
+    @Test
+    @DisplayName("codeが非常に長い文字列の場合、UNKNOWNが返されるべき")
+    void shouldReturnUnknownWhenCodeIsVeryLong() {
+      // Arrange
+      String code = "1234567890";
+
+      // Act
+      RoleChangeRequestType result = RoleChangeRequestType.valueOfCode(code);
+
+      // Assert
+      assertThat(result).isEqualTo(RoleChangeRequestType.UNKNOWN);
+    }
+
+    @Test
+    @DisplayName("codeが単一の数字以外の場合、UNKNOWNが返されるべき")
+    void shouldReturnUnknownWhenCodeIsSingleDigit() {
+      // Arrange
+      String code = "5";
+
+      // Act
+      RoleChangeRequestType result = RoleChangeRequestType.valueOfCode(code);
+
+      // Assert
+      assertThat(result).isEqualTo(RoleChangeRequestType.UNKNOWN);
+    }
+  }
+
+  @Nested
+  @DisplayName("Jackson Serialization/Deserializationのテスト")
+  class JacksonSerializationTest {
+
+    private final com.fasterxml.jackson.databind.ObjectMapper objectMapper = 
+        new com.fasterxml.jackson.databind.ObjectMapper();
+
+    @Test
+    @DisplayName("CREATEをJSONにシリアライズするとコード値が出力されるべき")
+    void shouldSerializeCreateToJsonCode() throws Exception {
+      // Act
+      String json = objectMapper.writeValueAsString(RoleChangeRequestType.CREATE);
+
+      // Assert
+      assertThat(json).isEqualTo("\"00\"");
+    }
+
+    @Test
+    @DisplayName("UPDATEをJSONにシリアライズするとコード値が出力されるべき")
+    void shouldSerializeUpdateToJsonCode() throws Exception {
+      // Act
+      String json = objectMapper.writeValueAsString(RoleChangeRequestType.UPDATE);
+
+      // Assert
+      assertThat(json).isEqualTo("\"10\"");
+    }
+
+    @Test
+    @DisplayName("DELETEをJSONにシリアライズするとコード値が出力されるべき")
+    void shouldSerializeDeleteToJsonCode() throws Exception {
+      // Act
+      String json = objectMapper.writeValueAsString(RoleChangeRequestType.DELETE);
+
+      // Assert
+      assertThat(json).isEqualTo("\"20\"");
+    }
+
+    @Test
+    @DisplayName("UNKNOWNをJSONにシリアライズするとコード値が出力されるべき")
+    void shouldSerializeUnknownToJsonCode() throws Exception {
+      // Act
+      String json = objectMapper.writeValueAsString(RoleChangeRequestType.UNKNOWN);
+
+      // Assert
+      assertThat(json).isEqualTo("\"00\"");
+    }
+
+    @Test
+    @DisplayName("コード'10'のJSONをデシリアライズするとCREATEになるべき")
+    void shouldDeserializeJsonCodeToCreate() throws Exception {
+      // Arrange
+      String json = "\"10\"";
+
+      // Act
+      RoleChangeRequestType result = objectMapper.readValue(json, RoleChangeRequestType.class);
+
+      // Assert
+      assertThat(result).isEqualTo(RoleChangeRequestType.CREATE);
+    }
+
+    @Test
+    @DisplayName("コード'20'のJSONをデシリアライズするとUPDATEになるべき")
+    void shouldDeserializeJsonCodeToUpdate() throws Exception {
+      // Arrange
+      String json = "\"20\"";
+
+      // Act
+      RoleChangeRequestType result = objectMapper.readValue(json, RoleChangeRequestType.class);
+
+      // Assert
+      assertThat(result).isEqualTo(RoleChangeRequestType.UPDATE);
+    }
+
+    @Test
+    @DisplayName("コード'30'のJSONをデシリアライズするとDELETEになるべき")
+    void shouldDeserializeJsonCodeToDelete() throws Exception {
+      // Arrange
+      String json = "\"30\"";
+
+      // Act
+      RoleChangeRequestType result = objectMapper.readValue(json, RoleChangeRequestType.class);
+
+      // Assert
+      assertThat(result).isEqualTo(RoleChangeRequestType.DELETE);
+    }
+
+    @Test
+    @DisplayName("不正なコードのJSONをデシリアライズするとUNKNOWNになるべき")
+    void shouldDeserializeInvalidJsonCodeToUnknown() throws Exception {
+      // Arrange
+      String json = "\"99\"";
+
+      // Act
+      RoleChangeRequestType result = objectMapper.readValue(json, RoleChangeRequestType.class);
+
+      // Assert
+      assertThat(result).isEqualTo(RoleChangeRequestType.UNKNOWN);
+    }
+
+    @Test
+    @DisplayName("nullのJSONをデシリアライズするとIllegalArgumentExceptionがスローされるべき")
+    void shouldThrowExceptionWhenDeserializingNullJson() {
+      // Arrange
+      String json = "null";
+
+      // Act & Assert
+      assertThatThrownBy(() -> objectMapper.readValue(json, RoleChangeRequestType.class))
+          .isInstanceOf(com.fasterxml.jackson.databind.JsonMappingException.class);
+    }
+
+    @Test
+    @DisplayName("シリアライズとデシリアライズのラウンドトリップが正常に機能すべき（CREATE）")
+    void shouldRoundTripSerializationForCreate() throws Exception {
+      // Arrange
+      RoleChangeRequestType original = RoleChangeRequestType.CREATE;
+
+      // Act
+      String json = objectMapper.writeValueAsString(original);
+      RoleChangeRequestType result = objectMapper.readValue(json, RoleChangeRequestType.class);
+
+      // Assert
+      assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    @DisplayName("シリアライズとデシリアライズのラウンドトリップが正常に機能すべき（UPDATE）")
+    void shouldRoundTripSerializationForUpdate() throws Exception {
+      // Arrange
+      RoleChangeRequestType original = RoleChangeRequestType.UPDATE;
+
+      // Act
+      String json = objectMapper.writeValueAsString(original);
+      RoleChangeRequestType result = objectMapper.readValue(json, RoleChangeRequestType.class);
+
+      // Assert
+      assertThat(result).isEqualTo(original);
+    }
+
+    @Test
+    @DisplayName("シリアライズとデシリアライズのラウンドトリップが正常に機能すべき（DELETE）")
+    void shouldRoundTripSerializationForDelete() throws Exception {
+      // Arrange
+      RoleChangeRequestType original = RoleChangeRequestType.DELETE;
+
+      // Act
+      String json = objectMapper.writeValueAsString(original);
+      RoleChangeRequestType result = objectMapper.readValue(json, RoleChangeRequestType.class);
+
+      // Assert
+      assertThat(result).isEqualTo(original);
+    }
+  }
+
+  @Nested
+  @DisplayName("Enumの基本機能のテスト")
+  class EnumBasicFunctionalityTest {
+
+    @Test
+    @DisplayName("values()は全てのenum定数を返すべき")
+    void shouldReturnAllEnumConstants() {
+      // Act
+      RoleChangeRequestType[] values = RoleChangeRequestType.values();
+
+      // Assert
+      assertThat(values)
+          .hasSize(4)
+          .containsExactly(
+              RoleChangeRequestType.CREATE,
+              RoleChangeRequestType.UPDATE,
+              RoleChangeRequestType.DELETE,
+              RoleChangeRequestType.UNKNOWN
+          );
+    }
+
+    @Test
+    @DisplayName("valueOf()は正しいenum定数を返すべき")
+    void shouldReturnCorrectEnumConstantByName() {
+      // Act & Assert
+      assertThat(RoleChangeRequestType.valueOf("CREATE"))
+          .isEqualTo(RoleChangeRequestType.CREATE);
+      assertThat(RoleChangeRequestType.valueOf("UPDATE"))
+          .isEqualTo(RoleChangeRequestType.UPDATE);
+      assertThat(RoleChangeRequestType.valueOf("DELETE"))
+          .isEqualTo(RoleChangeRequestType.DELETE);
+      assertThat(RoleChangeRequestType.valueOf("UNKNOWN"))
+          .isEqualTo(RoleChangeRequestType.UNKNOWN);
+    }
+
+    @Test
+    @DisplayName("valueOf()に不正な名前を渡すとIllegalArgumentExceptionがスローされるべき")
+    void shouldThrowExceptionForInvalidEnumName() {
+      // Act & Assert
+      assertThatThrownBy(() -> RoleChangeRequestType.valueOf("INVALID"))
+          .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("name()は正しいenum定数名を返すべき")
+    void shouldReturnCorrectEnumName() {
+      // Act & Assert
+      assertThat(RoleChangeRequestType.CREATE.name()).isEqualTo("CREATE");
+      assertThat(RoleChangeRequestType.UPDATE.name()).isEqualTo("UPDATE");
+      assertThat(RoleChangeRequestType.DELETE.name()).isEqualTo("DELETE");
+      assertThat(RoleChangeRequestType.UNKNOWN.name()).isEqualTo("UNKNOWN");
+    }
+
+    @Test
+    @DisplayName("ordinal()は正しいインデックスを返すべき")
+    void shouldReturnCorrectOrdinal() {
+      // Act & Assert
+      assertThat(RoleChangeRequestType.CREATE.ordinal()).isEqualTo(0);
+      assertThat(RoleChangeRequestType.UPDATE.ordinal()).isEqualTo(1);
+      assertThat(RoleChangeRequestType.DELETE.ordinal()).isEqualTo(2);
+      assertThat(RoleChangeRequestType.UNKNOWN.ordinal()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("toString()は正しいenum定数名を返すべき")
+    void shouldReturnCorrectToString() {
+      // Act & Assert
+      assertThat(RoleChangeRequestType.CREATE.toString()).isEqualTo("CREATE");
+      assertThat(RoleChangeRequestType.UPDATE.toString()).isEqualTo("UPDATE");
+      assertThat(RoleChangeRequestType.DELETE.toString()).isEqualTo("DELETE");
+      assertThat(RoleChangeRequestType.UNKNOWN.toString()).isEqualTo("UNKNOWN");
+    }
+
+    @Test
+    @DisplayName("compareTo()はordinal順で比較すべき")
+    void shouldCompareByOrdinal() {
+      // Act & Assert
+      assertThat(RoleChangeRequestType.CREATE.compareTo(RoleChangeRequestType.UPDATE))
+          .isNegative();
+      assertThat(RoleChangeRequestType.DELETE.compareTo(RoleChangeRequestType.CREATE))
+          .isPositive();
+      assertThat(RoleChangeRequestType.UPDATE.compareTo(RoleChangeRequestType.UPDATE))
+          .isZero();
+    }
+
+    @Test
+    @DisplayName("同じenum定数は==で比較できるべき")
+    void shouldBeComparableWithEqualityOperator() {
+      // Arrange
+      RoleChangeRequestType type1 = RoleChangeRequestType.CREATE;
+      RoleChangeRequestType type2 = RoleChangeRequestType.CREATE;
+
+      // Act & Assert
+      assertThat(type1 == type2).isTrue();
+      assertThat(type1).isSameAs(type2);
+    }
+  }
 }

--- a/backend/src/test/java/undecided/erp/role/RoleChangeRequestTypeTest.java
+++ b/backend/src/test/java/undecided/erp/role/RoleChangeRequestTypeTest.java
@@ -1,0 +1,94 @@
+package undecided.erp.role;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("RoleChangeRequestTypeクラスのテスト")
+class RoleChangeRequestTypeTest {
+
+  @Nested
+  @DisplayName("valueOfCodeメソッドのテスト")
+  class ValueOfCodeTest {
+
+    @Test
+    @DisplayName("codeがnullの場合、IllegalArgumentExceptionがスローされるべき")
+    void shouldThrowIllegalArgumentExceptionWhenCodeIsNull() {
+      // Arrange
+      String code = null;
+
+      // Act & Assert
+      assertThatThrownBy(() -> RoleChangeRequestType.valueOfCode(code))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessage("code must not be null.");
+    }
+
+    @Test
+    @DisplayName("codeが空文字の場合、UNKNOWNが返されるべき")
+    void shouldReturnUnknownWhenCodeIsEmpty() {
+      // Arrange
+      String code = "";
+
+      // Act
+      RoleChangeRequestType result = RoleChangeRequestType.valueOfCode(code);
+
+      // Assert
+      assertThat(result).isEqualTo(RoleChangeRequestType.UNKNOWN);
+    }
+
+    @Test
+    @DisplayName("codeが'10'の場合、CREATEが返されるべき")
+    void shouldReturnCreateWhenCodeIs10() {
+      // Arrange
+      String code = "10";
+
+      // Act
+      RoleChangeRequestType result = RoleChangeRequestType.valueOfCode(code);
+
+      // Assert
+      assertThat(result).isEqualTo(RoleChangeRequestType.CREATE);
+    }
+
+    @Test
+    @DisplayName("codeが'20'の場合、UPDATEが返されるべき")
+    void shouldReturnUpdateWhenCodeIs20() {
+      // Arrange
+      String code = "20";
+
+      // Act
+      RoleChangeRequestType result = RoleChangeRequestType.valueOfCode(code);
+
+      // Assert
+      assertThat(result).isEqualTo(RoleChangeRequestType.UPDATE);
+    }
+
+    @Test
+    @DisplayName("codeが'30'の場合、DELETEが返されるべき")
+    void shouldReturnDeleteWhenCodeIs30() {
+      // Arrange
+      String code = "30";
+
+      // Act
+      RoleChangeRequestType result = RoleChangeRequestType.valueOfCode(code);
+
+      // Assert
+      assertThat(result).isEqualTo(RoleChangeRequestType.DELETE);
+    }
+
+    @Test
+    @DisplayName("codeが不正な値の場合、UNKNOWNが返されるべき")
+    void shouldReturnUnknownWhenCodeIsInvalid() {
+      // Arrange
+      String code = "99";
+
+      // Act
+      RoleChangeRequestType result = RoleChangeRequestType.valueOfCode(code);
+
+      // Assert
+      assertThat(result).isEqualTo(RoleChangeRequestType.UNKNOWN);
+    }
+  }
+}


### PR DESCRIPTION
Introduced unit tests for the `RoleChangeRequestType` class to ensure the `valueOfCode` method handles various cases, including null, empty, valid, and invalid codes, correctly.

fix: #84

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ロール変更リクエストの種別（作成・更新・削除・不明）を明確化し、種別ごとの表示順序を導入しました。
* **テスト**
  * 種別の判定・コード値・順序・JSON入出力を網羅する包括的な単体テストを追加しました。空文字・不正値などの境界ケースも検証します。
* **不具合**
  * テストにより一部種別のシリアライズ/デシリアライズ挙動の不整合が検出されました（影響範囲と修正を要確認）。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->