### PR TITLE
Update devcontainer to use Redis instead of Valkey

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data  # データの永続化
 
-  # Valkeyサーバー（Redisの代替）
+  # Redisサーバー
   redis:
     container_name: ${PROJECT_NAME:-default}-redis_server
     image: redis/redis-stack-server:latest
@@ -32,7 +32,7 @@ services:
       # 開発環境でのみ空のパスワードを許可
       - ALLOW_EMPTY_PASSWORD=yes
       # 危険なコマンドを無効化
-      - VALKEY_DISABLE_COMMANDS=FLUSHDB,FLUSHALL
+      - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL
     ports:
       - '6379:6379'  # Redisの標準ポート
     volumes:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -4,14 +4,14 @@ version: "3.8"
 # 永続化ボリュームの定義
 volumes:
   postgres_data:  # PostgreSQLデータ用の永続化ボリューム
-  valkey_data: # Valkeyデータ用の永続化ボリューム
+  redis_data: # Valkeyデータ用の永続化ボリューム
     driver: local
 
 services:
   # PostgreSQLデータベースサービス
   db:
     container_name: ${PROJECT_NAME:-default}-postgresdb
-    image: postgres:latest
+    image: postgres:17.0
     restart: unless-stopped  # 停止されない限り再起動
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}          # PostgreSQLユーザー名
@@ -25,9 +25,9 @@ services:
       - postgres_data:/var/lib/postgresql/data  # データの永続化
 
   # Valkeyサーバー（Redisの代替）
-  valkey:
-    container_name: ${PROJECT_NAME:-default}-valkey_server
-    image: docker.io/bitnami/valkey:8.0
+  redis:
+    container_name: ${PROJECT_NAME:-default}-redis_server
+    image: redis/redis-stack-server:latest
     environment:
       # 開発環境でのみ空のパスワードを許可
       - ALLOW_EMPTY_PASSWORD=yes
@@ -36,7 +36,7 @@ services:
     ports:
       - '6379:6379'  # Redisの標準ポート
     volumes:
-      - 'valkey_data:/bitnami/valkey/data'  # データの永続化
+      - 'redis_data:/bitnami/redis/data'  # データの永続化
     depends_on:
       - db  # データベースサービスが起動してから開始
 
@@ -94,6 +94,6 @@ services:
     depends_on:
       - service-registry  # サービスレジストリ
       - db               # データベース
-      - valkey          # Valkeyサーバー
+      - redis          # Valkeyサーバー
       - zipkin          # Zipkinサーバー
     command: sleep infinity  # 開発環境用：コンテナを永続化

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -4,7 +4,7 @@ version: "3.8"
 # 永続化ボリュームの定義
 volumes:
   postgres_data:  # PostgreSQLデータ用の永続化ボリューム
-  redis_data: # Valkeyデータ用の永続化ボリューム
+  redis_data: # Redisデータ用の永続化ボリューム
     driver: local
 
 services:
@@ -94,6 +94,6 @@ services:
     depends_on:
       - service-registry  # サービスレジストリ
       - db               # データベース
-      - redis          # Valkeyサーバー
+      - redis          # Redisサーバー
       - zipkin          # Zipkinサーバー
     command: sleep infinity  # 開発環境用：コンテナを永続化


### PR DESCRIPTION
Updated the `.devcontainer/docker-compose.yml` configuration to replace Valkey with Redis. Adjusted service definitions, environment variables, and volume configurations accordingly. Also updated the PostgreSQL image to version 17.0 to ensure compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 開発環境のPostgreSQLをバージョン17.0に更新しました
  * キャッシュ層を Valkey から Redis（Redis Stack）へ切り替えました
  * キャッシュ関連の環境設定名と無効化設定をRedis向けに変更しました
  * データボリューム名とサービス依存関係をRedisに合わせて更新しました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->