### PR TITLE
Add OAuth2 server and refine devcontainer setup

### DIFF
--- a/authorization/build.gradle.kts
+++ b/authorization/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
     annotationProcessor("org.projectlombok:lombok")
     implementation("org.springframework.boot:spring-boot-starter-cache")
     implementation("com.github.ben-manes.caffeine:caffeine")
+    implementation("org.springframework.security:spring-security-oauth2-authorization-server:7.0.0")
 }
 
 tasks.withType<Javadoc> {


### PR DESCRIPTION
### Summary

This pull request introduces the following changes:

- **New Feature**: Added `spring-security-oauth2-authorization-server` dependency to enable OAuth2 authorization server functionality.
- **Bug Fixes and Updates**:
  - Corrected Redis-related comments and configuration in `.devcontainer/docker-compose.yml` to replace outdated "Valkey" references with accurate Redis terminology.
  - Adjusted environment variables and service configurations for Redis consistency.
  - Updated PostgreSQL image version to 17.0 for compatibility. 

### Checklist

- [ ] Unit tests have been added/updated if applicable
- [ ] Documentation has been updated if applicable
- [ ] All commits follow the Git conventions
fix: #87