### PR TITLE
Add exception logging advisor to SpringMvcRestConfig

### DIFF
--- a/backend/src/main/java/undecided/erp/employee/internal/EmployeeApi.java
+++ b/backend/src/main/java/undecided/erp/employee/internal/EmployeeApi.java
@@ -1,0 +1,15 @@
+package undecided.erp.employee.internal;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import undecided.erp.employee.Employee;
+
+@RestController
+@RequestMapping("/api/employees")
+public class EmployeeApi {
+  @GetMapping
+  Employee get() {
+    return new Employee();
+  }
+}

--- a/backend/src/main/java/undecided/erp/greeting/internal/GreetingApi.java
+++ b/backend/src/main/java/undecided/erp/greeting/internal/GreetingApi.java
@@ -3,13 +3,15 @@ package undecided.erp.greeting.internal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import undecided.erp.common.exception.BusinessException;
+import undecided.erp.common.message.ResultMessages;
 
 @RestController
 @RequestMapping("/api/greeting")
 public class GreetingApi {
   @GetMapping
   String get() {
-    // throw new BusinessException(ResultMessages.warning().add("CODE"));
-    return "Hello World";
+    throw new BusinessException(ResultMessages.info().add("CODE"));
+    // return "Hello World";
   }
 }

--- a/backend/src/main/java/undecided/erp/organization/internal/OrganizationApi.java
+++ b/backend/src/main/java/undecided/erp/organization/internal/OrganizationApi.java
@@ -1,11 +1,11 @@
 package undecided.erp.organization.internal;
 
 import jakarta.persistence.EntityNotFoundException;
-import jakarta.websocket.server.PathParam;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import undecided.erp.organization.spi.Organization;
@@ -36,7 +36,7 @@ public class OrganizationApi {
    * @throws EntityNotFoundException 指定されたIDに対応する組織が見つからない場合
    */
   @GetMapping("/{id}")
-  Organization findById(@PathParam("id") UUID id) {
+  Organization findById(@PathVariable("id") UUID id) {
     return organizationQuery
         .findById(id)
         .orElseThrow(() -> new EntityNotFoundException("Organization not found: " + id + ""));

--- a/backend/src/main/java/undecided/erp/organization/internal/OrganizationApi.java
+++ b/backend/src/main/java/undecided/erp/organization/internal/OrganizationApi.java
@@ -1,0 +1,44 @@
+package undecided.erp.organization.internal;
+
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.websocket.server.PathParam;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import undecided.erp.organization.spi.Organization;
+import undecided.erp.organization.spi.OrganizationQuery;
+
+/** 組織に関連するAPIエンドポイントを提供するコントローラクラスです。 このクラスは組織データの取得およびIDを基にした検索機能を提供します。 */
+@RestController
+@RequestMapping("/api/organizations")
+@RequiredArgsConstructor
+public class OrganizationApi {
+  private final OrganizationQuery organizationQuery;
+
+  /**
+   * すべての組織データを取得します。
+   *
+   * @return 組織オブジェクトのリスト
+   */
+  @GetMapping()
+  List<Organization> findAll() {
+    return organizationQuery.findAll();
+  }
+
+  /**
+   * 指定されたIDに基づいて組織を検索します。
+   *
+   * @param id 検索対象の組織を識別するUUID
+   * @return 指定されたIDに対応する組織オブジェクト
+   * @throws EntityNotFoundException 指定されたIDに対応する組織が見つからない場合
+   */
+  @GetMapping("/{id}")
+  Organization findById(@PathParam("id") UUID id) {
+    return organizationQuery
+        .findById(id)
+        .orElseThrow(() -> new EntityNotFoundException("Organization not found: " + id + ""));
+  }
+}

--- a/backend/src/main/java/undecided/erp/organization/internal/OrganizationQueryImpl.java
+++ b/backend/src/main/java/undecided/erp/organization/internal/OrganizationQueryImpl.java
@@ -1,0 +1,26 @@
+package undecided.erp.organization.internal;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import undecided.erp.common.primitive.Lists2;
+import undecided.erp.organization.spi.Organization;
+import undecided.erp.organization.spi.OrganizationQuery;
+
+@Service
+@RequiredArgsConstructor
+public class OrganizationQueryImpl implements OrganizationQuery {
+  private final OrganizationRepository organizationRepository;
+
+  @Override
+  public List<Organization> findAll() {
+    return Lists2.newArrayList(organizationRepository.findAll());
+  }
+
+  @Override
+  public Optional<Organization> findById(UUID id) {
+    return organizationRepository.findById(id);
+  }
+}

--- a/backend/src/main/java/undecided/erp/organization/internal/OrganizationRepository.java
+++ b/backend/src/main/java/undecided/erp/organization/internal/OrganizationRepository.java
@@ -1,8 +1,9 @@
-package undecided.erp.organization.spi;
+package undecided.erp.organization.internal;
 
 import java.util.UUID;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
+import undecided.erp.organization.spi.Organization;
 
 @Repository
 public interface OrganizationRepository extends CrudRepository<Organization, UUID> {}

--- a/backend/src/main/java/undecided/erp/organization/spi/OrganizationQuery.java
+++ b/backend/src/main/java/undecided/erp/organization/spi/OrganizationQuery.java
@@ -1,0 +1,24 @@
+package undecided.erp.organization.spi;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/** 組織情報を取得するためのクエリインターフェースです。 このインターフェースを実装することで、組織のデータにアクセスするための 機能を提供します。 */
+public interface OrganizationQuery {
+
+  /**
+   * 全ての組織情報を取得します。
+   *
+   * @return 現在利用可能な全ての組織データのリスト
+   */
+  List<Organization> findAll();
+
+  /**
+   * 指定された UUID に対応する組織情報を検索します。
+   *
+   * @param id 検索対象の組織を一意に識別するための UUID
+   * @return 指定された UUID に対応する組織の情報を含む Optional 存在しない場合は Optional.empty() を返します
+   */
+  Optional<Organization> findById(UUID id);
+}

--- a/backend/src/main/java/undecided/erp/role/internal/RoleApi.java
+++ b/backend/src/main/java/undecided/erp/role/internal/RoleApi.java
@@ -1,0 +1,28 @@
+package undecided.erp.role.internal;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import undecided.erp.role.spi.Role;
+
+/**
+ * RoleApiは、ロール情報を管理するためのREST APIコントローラーです。
+ *
+ * <p>主に以下の機能を提供します: - 指定されたエンドポイントへのリクエストに対して、ロール情報を返却します。
+ *
+ * <p>アノテーション: - `@RestController`: Spring FrameworkにおけるREST APIコントローラーとしての役割を示します。 -
+ * `@RequestMapping`: 基本URLを設定し、このコントローラーが処理するリクエストを定義します。 - `@GetMapping`: HTTP
+ * GETリクエストをこのメソッドにマッピングします。
+ *
+ * <p>エンドポイント: - `/api/roles`: 基本URLにマッピングされており、ロールデータを返却するために使用されます。
+ *
+ * <p>戻り値: - `Role`: システムで管理されるロールを表すオブジェクト。
+ */
+@RestController
+@RequestMapping("/api/roles")
+public class RoleApi {
+  @GetMapping
+  Role get() {
+    return new Role();
+  }
+}

--- a/backend/src/main/java/undecided/erp/role/internal/RoleAssignmentsForEmpApi.java
+++ b/backend/src/main/java/undecided/erp/role/internal/RoleAssignmentsForEmpApi.java
@@ -1,0 +1,28 @@
+package undecided.erp.role.internal;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import undecided.erp.role.spi.RoleAssignmentForEmp;
+
+/**
+ * RoleAssignmentsForEmpApiは、従業員に関連付けられたロールの情報を取得するためのREST APIコントローラーです。
+ *
+ * <p>主に以下の機能を提供します: - 指定されたエンドポイントへのリクエストに対して、従業員のロール割り当て情報を返却する。
+ *
+ * <p>アノテーション: - `@RestController`: Spring Frameworkにおいて、REST APIコントローラーとしての役割を示します。 -
+ * `@RequestMapping`: このコントローラーが処理するリクエストの基本URLを定義します。 - `@GetMapping`: HTTP
+ * GETリクエストをマッピングし、そのリクエストに対応する処理を指定します。
+ *
+ * <p>エンドポイント: - `/api/roleAssignmentsFor`: 基本URLにマッピングされており、ロール割り当てデータを返却します。
+ *
+ * <p>戻り値: - `RoleAssignmentForEmp`: 従業員に対するロール割り当てを表すオブジェクト。
+ */
+@RestController
+@RequestMapping("/api/roleAssignmentsFor")
+public class RoleAssignmentsForEmpApi {
+  @GetMapping
+  RoleAssignmentForEmp get() {
+    return new RoleAssignmentForEmp();
+  }
+}

--- a/backend/src/main/java/undecided/erp/role/internal/RoleAssignmentsForOrgApi.java
+++ b/backend/src/main/java/undecided/erp/role/internal/RoleAssignmentsForOrgApi.java
@@ -1,0 +1,28 @@
+package undecided.erp.role.internal;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import undecided.erp.role.spi.RoleAssignmentForOrg;
+
+/**
+ * RoleAssignmentsForOrgApiは、組織に関連付けられたロールの割り当て情報を取得するためのREST APIコントローラーです。
+ *
+ * <p>主に以下の機能を提供します: - 指定されたエンドポイントへのリクエストに対して、組織に関連するロール割り当て情報を返却する。
+ *
+ * <p>アノテーション: - `@RestController`: このクラスがSpring FrameworkにおいてREST APIコントローラーとして動作することを示します。 -
+ * `@RequestMapping`: このコントローラーが処理するリクエストの基本URLを定義します。 - `@GetMapping`: HTTP
+ * GETリクエストをこのメソッドにマッピングし、そのリクエストに対応する処理を定義します。
+ *
+ * <p>エンドポイント: - `/api/roleAssignmentsForOrg`: ロール割り当てデータを提供する基本エンドポイントです。
+ *
+ * <p>戻り値: - `RoleAssignmentForOrg`: 組織に対するロール割り当てを表すオブジェクト。
+ */
+@RestController
+@RequestMapping("/api/roleAssignmentsForOrg")
+public class RoleAssignmentsForOrgApi {
+  @GetMapping
+  RoleAssignmentForOrg get() {
+    return new RoleAssignmentForOrg();
+  }
+}

--- a/backend/src/main/java/undecided/erp/shared/applicatoion/SpringMvcRestConfig.java
+++ b/backend/src/main/java/undecided/erp/shared/applicatoion/SpringMvcRestConfig.java
@@ -37,19 +37,17 @@ public class SpringMvcRestConfig implements WebMvcConfigurer {
   }
 
   /**
-   * 例外を処理するためのLoggingInterceptorを含むAdvisorを提供します。
+   * HandlerExceptionResolverLoggingInterceptorを利用して、例外解決時のロギングを行う アドバイザーを生成します。
    *
-   * <p>このAdvisorは、指定されたパターンに一致するクラスおよびメソッドに適用されます。 例外が発生した場合に、それをログとして記録する機能を提供します。
-   *
-   * @param exceptionLogger 例外をログに記録するためのExceptionLoggerオブジェクト
-   * @return 設定されたポイントカットおよびInterceptorを含むAdvisor
+   * @param interceptor HandlerExceptionResolverLoggingInterceptorインスタンス。 例外処理時のロギング機能を提供します。
+   * @return ExceptionResolverLoggingInterceptorを適用するAdvisorインスタンス。
    */
   @Bean
-  public Advisor exceptionResolverLoggingInterceptorAdvisor(ExceptionLogger exceptionLogger) {
+  public Advisor exceptionResolverLoggingInterceptorAdvisor(
+      HandlerExceptionResolverLoggingInterceptor interceptor) {
     JdkRegexpMethodPointcut pointcut = new JdkRegexpMethodPointcut();
     pointcut.setPattern("undecided.erp.*.internal.*Api.*");
-    return new DefaultPointcutAdvisor(
-        pointcut, handlerExceptionResolverLoggingInterceptor(exceptionLogger));
+    return new DefaultPointcutAdvisor(pointcut, interceptor);
   }
 
   /**

--- a/backend/src/main/java/undecided/erp/shared/applicatoion/SpringMvcRestConfig.java
+++ b/backend/src/main/java/undecided/erp/shared/applicatoion/SpringMvcRestConfig.java
@@ -46,7 +46,7 @@ public class SpringMvcRestConfig implements WebMvcConfigurer {
   public Advisor exceptionResolverLoggingInterceptorAdvisor(
       HandlerExceptionResolverLoggingInterceptor interceptor) {
     JdkRegexpMethodPointcut pointcut = new JdkRegexpMethodPointcut();
-    pointcut.setPattern("undecided.erp.*.internal.*Api.*");
+    pointcut.setPattern("undecided.erp..internal.*Api.*");
     return new DefaultPointcutAdvisor(pointcut, interceptor);
   }
 

--- a/backend/src/main/java/undecided/erp/shared/applicatoion/SpringMvcRestConfig.java
+++ b/backend/src/main/java/undecided/erp/shared/applicatoion/SpringMvcRestConfig.java
@@ -47,7 +47,7 @@ public class SpringMvcRestConfig implements WebMvcConfigurer {
   @Bean
   public Advisor exceptionResolverLoggingInterceptorAdvisor(ExceptionLogger exceptionLogger) {
     JdkRegexpMethodPointcut pointcut = new JdkRegexpMethodPointcut();
-    pointcut.setPattern("undecided.erp.*.application.*Api.*");
+    pointcut.setPattern("undecided.erp.*.internal.*Api.*");
     return new DefaultPointcutAdvisor(
         pointcut, handlerExceptionResolverLoggingInterceptor(exceptionLogger));
   }

--- a/backend/src/main/java/undecided/erp/shared/applicatoion/SpringMvcRestConfig.java
+++ b/backend/src/main/java/undecided/erp/shared/applicatoion/SpringMvcRestConfig.java
@@ -2,6 +2,9 @@ package undecided.erp.shared.applicatoion;
 
 import com.fasterxml.jackson.databind.util.StdDateFormat;
 import java.util.concurrent.Executors;
+import org.springframework.aop.Advisor;
+import org.springframework.aop.support.DefaultPointcutAdvisor;
+import org.springframework.aop.support.JdkRegexpMethodPointcut;
 import org.springframework.boot.tomcat.reactive.TomcatReactiveWebServerFactory;
 import org.springframework.boot.web.server.WebServerFactoryCustomizer;
 import org.springframework.context.annotation.Bean;
@@ -18,6 +21,12 @@ import undecided.erp.common.web.logging.TraceLoggingInterceptor;
 @EnableAspectJAutoProxy(proxyTargetClass = true)
 @Configuration
 public class SpringMvcRestConfig implements WebMvcConfigurer {
+  /**
+   * HandlerExceptionResolverLoggingInterceptorを生成し、例外ログ設定を適用した後に返します。
+   *
+   * @param exceptionLogger 例外をログに記録するためのExceptionLoggerオブジェクト
+   * @return 初期化されたHandlerExceptionResolverLoggingInterceptorのインスタンス
+   */
   @Bean
   public HandlerExceptionResolverLoggingInterceptor handlerExceptionResolverLoggingInterceptor(
       ExceptionLogger exceptionLogger) {
@@ -25,6 +34,22 @@ public class SpringMvcRestConfig implements WebMvcConfigurer {
         new HandlerExceptionResolverLoggingInterceptor();
     handlerExceptionResolverLoggingInterceptor.setExceptionLogger(exceptionLogger);
     return handlerExceptionResolverLoggingInterceptor;
+  }
+
+  /**
+   * 例外を処理するためのLoggingInterceptorを含むAdvisorを提供します。
+   *
+   * <p>このAdvisorは、指定されたパターンに一致するクラスおよびメソッドに適用されます。 例外が発生した場合に、それをログとして記録する機能を提供します。
+   *
+   * @param exceptionLogger 例外をログに記録するためのExceptionLoggerオブジェクト
+   * @return 設定されたポイントカットおよびInterceptorを含むAdvisor
+   */
+  @Bean
+  public Advisor exceptionResolverLoggingInterceptorAdvisor(ExceptionLogger exceptionLogger) {
+    JdkRegexpMethodPointcut pointcut = new JdkRegexpMethodPointcut();
+    pointcut.setPattern("undecided.erp.*.application.*Api.*");
+    return new DefaultPointcutAdvisor(
+        pointcut, handlerExceptionResolverLoggingInterceptor(exceptionLogger));
   }
 
   /**


### PR DESCRIPTION
### Summary

- Added the `exceptionResolverLoggingInterceptorAdvisor` bean to improve exception logging through AOP in `SpringMvcRestConfig`.
- Configured method pointcuts to match specific patterns for better control.
- Enhanced Javadoc documentation for improved clarity. 

### Why are these changes necessary?

To enable more comprehensive and efficient exception logging in SpringMvc-based REST applications.

### What has changed?

- New AOP advisor bean added.
- Pointcut pattern and method matching logic introduced.
- Updated relevant documentation. 

### What areas should reviewers pay attention to?

- Configuration of the `exceptionResolverLoggingInterceptorAdvisor`.
- Accuracy and clarity of the added Javadoc.
- Pointcut pattern scope and correctness.

### Testing

- [x] Unit tests
- [x] Integration tests
- [ ] Manual testing

fix: #104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 従業員、組織（一覧・詳細）、役割、および役割割当を取得する公開APIが追加されました。

* **改善**
  * API層の例外ログ記録がAOPアドバイザで強化され、例外の可視化と追跡が向上しました。

* **変更**
  * 挨拶APIの挙動が変更され、正常な文字列応答ではなく例外をスローするようになりました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->