### PR TITLE
Update Java toolchain to version 26

### DIFF
--- a/authorization/build.gradle.kts
+++ b/authorization/build.gradle.kts
@@ -20,7 +20,7 @@ version = "0.0.1-SNAPSHOT"
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(25))
+        languageVersion.set(JavaLanguageVersion.of(26))
     }
 }
 

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -28,7 +28,7 @@ version = "0.0.1-SNAPSHOT"
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(25))
+        languageVersion.set(JavaLanguageVersion.of(26))
     }
 
 }


### PR DESCRIPTION
```
### Summary

Updated the Java toolchain version in `build.gradle.kts` from version 25 to 26. This ensures compatibility with the latest Java language features and improvements.

### Checklist

- [ ] Reviewed changes for potential impact on existing functionality.
- [ ] Verified toolchain update avoids breaking changes in the build process.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Java toolchain をバージョン 26 に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->