### PR TITLE
Add resource for exception handling in Spring Boot

### DIFF
--- a/.junie/exception-handler.md
+++ b/.junie/exception-handler.md
@@ -1,0 +1,3 @@
+Exception Handling in Spring Boot: A Complete Guide for Production Applications
+-----
+https://www.baeldung.com/spring-boot-exception-handling


### PR DESCRIPTION
Added a reference in `.junie/exception-handler.md` to Baeldung's guide on "Exception Handling in Spring Boot." This serves as a helpful resource for managing exceptions in production applications.